### PR TITLE
Grouping issue: Add test for showing grouping issue

### DIFF
--- a/test/ecto/integration/grouping_test.exs
+++ b/test/ecto/integration/grouping_test.exs
@@ -5,7 +5,7 @@ defmodule Ecto.Integration.GroupingTest do
   alias Ecto.Integration.TestRepo
   alias Ecto.Integration.Post
 
-  test "Aggregating already known key" do
+  test "Grouping on already known field" do
     TestRepo.insert!(%Post{title: "1", counter: 1, public: true})
     TestRepo.insert!(%Post{title: "2", counter: 2, public: true})
     TestRepo.insert!(%Post{title: "3", counter: 3, public: true})
@@ -25,5 +25,27 @@ defmodule Ecto.Integration.GroupingTest do
 
     assert Enum.sort(data) ==
              Enum.sort([%{counter: 0, total_counter: 4}, %{counter: 1, total_counter: 6}])
+  end
+
+  test "Grouping on new selected field" do
+    TestRepo.insert!(%Post{title: "1", counter: 1, public: true})
+    TestRepo.insert!(%Post{title: "2", counter: 2, public: true})
+    TestRepo.insert!(%Post{title: "3", counter: 3, public: true})
+    TestRepo.insert!(%Post{title: "4", counter: 4, public: true})
+
+    data =
+      TestRepo.all(
+        from(
+          p in Post,
+          select: %{
+            even: fragment("modulo(?, 2) == 0", p.counter),
+            total_counter: sum(p.counter)
+          },
+          group_by: fragment("even")
+        )
+      )
+
+    assert Enum.sort(data) ==
+             Enum.sort([%{even: 0, total_counter: 4}, %{even: 1, total_counter: 6}])
   end
 end

--- a/test/ecto/integration/grouping_test.exs
+++ b/test/ecto/integration/grouping_test.exs
@@ -1,0 +1,29 @@
+defmodule Ecto.Integration.GroupingTest do
+  use Ecto.Integration.Case
+  import Ecto.Query
+
+  alias Ecto.Integration.TestRepo
+  alias Ecto.Integration.Post
+
+  test "Aggregating already known key" do
+    TestRepo.insert!(%Post{title: "1", counter: 1, public: true})
+    TestRepo.insert!(%Post{title: "2", counter: 2, public: true})
+    TestRepo.insert!(%Post{title: "3", counter: 3, public: true})
+    TestRepo.insert!(%Post{title: "4", counter: 4, public: true})
+
+    data =
+      TestRepo.all(
+        from(
+          p in Post,
+          select: %{
+            counter: fragment("modulo(?, 2) == 0", p.counter),
+            total_counter: sum(p.counter)
+          },
+          group_by: fragment("counter")
+        )
+      )
+
+    assert Enum.sort(data) ==
+             Enum.sort([%{counter: 0, total_counter: 4}, %{counter: 1, total_counter: 6}])
+  end
+end


### PR DESCRIPTION
Hey, I found one small other issue. 

The generated SQL for:
```elixir
TestRepo.all(
        from(
          p in Post,
          select: %{
            counter: fragment("modulo(?, 2) == 0", p.counter),
            total_counter: sum(p.counter)
          },
          group_by: fragment("counter")
        )
      )
```

is 

```sql
SELECT modulo(p0."counter", 2) == 0, sum(p0."counter") FROM "posts" AS p0 GROUP BY counter
```

but it should be
```sql
SELECT modulo(p0."counter", 2) == 0 as counter, sum(p0."counter") as total_counter FROM "posts" AS p0 GROUP BY counter
```

Because now clickhouse does not group by the grouped by field but by column `counter`. 

Essentially if it would be possible to add `as <selecting_field>` to every channel that would solve the issue.

Queries such as
```elixir
from(
          p in Post,
          select: %{
            even: fragment("modulo(?, 2) == 0", p.counter),
            total_counter: sum(p.counter)
          },
          group_by: fragment("even")
        )
```
will fail with 
```bash
Code: 47. DB::Exception: Missing columns: 'even' while processing query: 'SELECT (counter % 2) = 0, sum(counter) FROM posts AS p0 GROUP BY even', required columns: 'even' 'counter', maybe you meant: ['counter'].
```

Hope this helps! 