### PR TITLE
add :default_table_engine option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,5 @@
 # Changelog
+
+## Unreleased
+
+- add `:default_table_engine` option https://github.com/plausible/ecto_ch/pull/58

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ defmodule MyApp.Repo do
 end
 ```
 
+Optionally you can also set the default table engine to use in migrations
+
+```elixir
+config :ecto_ch, default_table_engine: "TinyLog"
+```
+
 #### Ecto schemas
 
 For automatic RowBinary encoding please use the custom `Ch` Ecto type:

--- a/lib/ecto/adapters/clickhouse/migration.ex
+++ b/lib/ecto/adapters/clickhouse/migration.ex
@@ -16,7 +16,7 @@ defmodule Ecto.Adapters.ClickHouse.Migration do
         :create_if_not_exists -> "CREATE TABLE IF NOT EXISTS "
       end
 
-    engine = engine || "TinyLog"
+    engine = engine || Application.get_env(:ecto_ch, :default_table_engine) || "TinyLog"
     pk = if engine in ["TinyLog", "Memory"], do: [], else: pk_definition(columns)
     columns = @conn.intersperse_map(columns, ?,, &column_definition/1)
     options = options_expr(options)


### PR DESCRIPTION
closes #47 

The default behaviour is unchanged (`TinyLog`), but now users can specify their own default and it would be used in all new tables, including  `schema_migrations`