### PR TITLE
[feature] Added constraint support in migrations

### DIFF
--- a/lib/ecto/adapters/clickhouse/migration.ex
+++ b/lib/ecto/adapters/clickhouse/migration.ex
@@ -122,6 +122,10 @@ defmodule Ecto.Adapters.ClickHouse.Migration do
       raise "Clickhouse adapter does not support exclude constraints"
     end
 
+    unless constraint.check do
+      raise "Clickhouse adapter requires check option for constraints"
+    end
+
     add =
       case command do
         :create -> " ADD CONSTRAINT "

--- a/lib/ecto/adapters/clickhouse/migration.ex
+++ b/lib/ecto/adapters/clickhouse/migration.ex
@@ -119,9 +119,22 @@ defmodule Ecto.Adapters.ClickHouse.Migration do
     raise "TODO"
   end
 
-  def execute_ddl({command, %Constraint{} = _constraint, _mode})
+  def execute_ddl({command, %Constraint{} = constraint, _mode})
       when command in [:drop, :drop_if_exists] do
-    raise "TODO"
+    drop =
+      case command do
+        :drop -> " DROP CONSTRAINT "
+        :drop_if_exists -> " DROP CONSTRAINT IF EXISTS "
+      end
+
+    [
+      [
+        "ALTER TABLE ",
+        @conn.quote_table(constraint.prefix, constraint.table),
+        drop,
+        @conn.quote_name(constraint.name)
+      ]
+    ]
   end
 
   def execute_ddl({:rename, %Table{} = current_table, %Table{} = new_table}) do

--- a/test/ecto/adapters/clickhouse/connection_test.exs
+++ b/test/ecto/adapters/clickhouse/connection_test.exs
@@ -2382,10 +2382,12 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
     assert execute_ddl(drop) == [~s|DROP INDEX "posts$main"|]
   end
 
-  @tag skip: true
   test "create check constraint" do
     create = {:create, constraint(:products, "price_must_be_positive", check: "price > 0")}
-    assert execute_ddl(create) == []
+
+    assert execute_ddl(create) == [
+             ~s|ALTER TABLE "products" ADD CONSTRAINT "price_must_be_positive" CHECK (price > 0)|
+           ]
 
     create =
       {:create,
@@ -2394,7 +2396,9 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
          prefix: "foo"
        )}
 
-    assert execute_ddl(create) == []
+    assert execute_ddl(create) == [
+             ~s|ALTER TABLE "foo"."products" ADD CONSTRAINT "price_must_be_positive" CHECK (price > 0)|
+           ]
   end
 
   @tag skip: true

--- a/test/ecto/adapters/clickhouse/connection_test.exs
+++ b/test/ecto/adapters/clickhouse/connection_test.exs
@@ -2057,21 +2057,21 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
     assert execute_ddl(drop) == [~s|DROP TABLE "foo"."posts"|]
   end
 
-  @tag skip: true
   test "drop constraint" do
     drop = {:drop, constraint(:products, "price_must_be_positive", prefix: :foo), :restrict}
 
     assert execute_ddl(drop) == [
-             ~s{DROP CONSTRAINT}
+             ~s|ALTER TABLE "foo"."products" DROP CONSTRAINT "price_must_be_positive"|
            ]
   end
 
-  @tag skip: true
   test "drop_if_exists constraint" do
     drop =
       {:drop_if_exists, constraint(:products, "price_must_be_positive", prefix: :foo), :restrict}
 
-    assert execute_ddl(drop) == []
+    assert execute_ddl(drop) == [
+             ~s|ALTER TABLE "foo"."products" DROP CONSTRAINT IF EXISTS "price_must_be_positive"|
+           ]
   end
 
   test "alter table" do


### PR DESCRIPTION
Hello, there was no support for constraint in create, create_if_not_exists, drop, drop_if_exists. Need to run those through execute. So I decided to contribute and add this small feature.