### PR TITLE
add: support for ON CLUSTER

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,27 @@ Optionally you can also set the default table engine to use in migrations
 config :ecto_ch, default_table_engine: "TinyLog"
 ```
 
+Optionally you can have the migrations perform the changes using [`ON CLUSTER`](https://clickhouse.com/docs/en/sql-reference/distributed-ddl)
+Either globally
+
+```elixir
+config :ecto_ch, cluster_name: "name-of-cluster"
+```
+
+Or for a specific migration.
+
+```elixir
+  use Ecto.Migration
+
+  def up() do
+    :ok = Application.put_env(:ecto_ch, :cluster_name, "name-of-cluster")
+    create table(...
+
+
+    :ok = Application.delete_env(:ecto_ch, :cluster_name)
+  end
+```
+
 #### Ecto schemas
 
 For automatic RowBinary encoding please use the custom `Ch` Ecto type:

--- a/test/ecto/adapters/clickhouse/connection_test.exs
+++ b/test/ecto/adapters/clickhouse/connection_test.exs
@@ -1842,6 +1842,21 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
     assert execute_ddl(create) == [~s{CREATE TABLE "posts"() ENGINE=TinyLog}]
   end
 
+  test "create table uses :cluster when set" do
+    prev = Application.get_env(:ecto_ch, :cluster_name)
+    :ok = Application.put_env(:ecto_ch, :cluster_name, "cluster-name")
+
+    on_exit(fn ->
+      Application.put_env(:ecto_ch, :cluster_name, prev)
+    end)
+
+    create = {:create, table(:posts, engine: "ReplicatedMergeTree"), []}
+
+    assert execute_ddl(create) == [
+             ~s{CREATE TABLE "posts" ON CLUSTER "cluster-name" () ENGINE=ReplicatedMergeTree}
+           ]
+  end
+
   test "create empty table" do
     create = {:create, table(:posts), []}
     assert execute_ddl(create) == [~s{CREATE TABLE "posts"() ENGINE=TinyLog}]


### PR DESCRIPTION
I need to have the `schema_migrations` **and** all tables for my app get created with `ON CLUSTER our-cluster` to ensure that the tables get replicated from the start.

As I can't use the `:options` section in `Ecto.Migrations.Table`, because that is expected to be a `String` in this adapter, I've opted to use the Application Environment for configuring the `:cluster_name`.

Any feedback, positive or negative is appreciated.  