### PR TITLE
use documented syntax for add index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - ensure all colums are for the same table in `ecto.ch.schema` mix task https://github.com/plausible/ecto_ch/pull/118
+- switch from `CREATE INDEX` to `ALTER TABLE ... ADD INDEX` syntax for indexes https://github.com/plausible/ecto_ch/pull/120
 
 ## 0.2.2 (2023-08-29)
 

--- a/lib/ecto/adapters/clickhouse/migration.ex
+++ b/lib/ecto/adapters/clickhouse/migration.ex
@@ -75,18 +75,18 @@ defmodule Ecto.Adapters.ClickHouse.Migration do
 
     fields = @conn.intersperse_map(index.columns, ?,, &index_expr/1)
 
-    create =
+    add =
       case command do
-        :create -> "CREATE INDEX "
-        :create_if_not_exists -> "CREATE INDEX IF NOT EXISTS "
+        :create -> " ADD INDEX "
+        :create_if_not_exists -> " ADD INDEX IF NOT EXISTS "
       end
 
     [
       [
-        create,
-        @conn.quote_name(index.name),
-        " ON ",
+        "ALTER TABLE ",
         @conn.quote_table(index.prefix, index.table),
+        add,
+        @conn.quote_name(index.name),
         " (",
         fields,
         ") TYPE ",

--- a/test/ecto/adapters/clickhouse/connection_test.exs
+++ b/test/ecto/adapters/clickhouse/connection_test.exs
@@ -2189,14 +2189,16 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
   test "create index" do
     create =
       {:create,
-       index(:posts, [:category_id, :permalink], options: [type: :range, granularity: 8126])}
+       index(:posts, [:category_id, :permalink],
+         options: [type: :bloom_filter, granularity: 8126]
+       )}
 
     assert execute_ddl(create) ==
              [
                """
-               CREATE INDEX "posts_category_id_permalink_index" \
-               ON "posts" ("category_id","permalink") \
-               TYPE range GRANULARITY 8126\
+               ALTER TABLE "posts" \
+               ADD INDEX "posts_category_id_permalink_index" ("category_id","permalink") \
+               TYPE bloom_filter GRANULARITY 8126\
                """
              ]
 
@@ -2204,14 +2206,14 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
       {:create,
        index(:posts, ["lower(permalink)"],
          name: "posts$main",
-         options: [type: :range, granularity: 8126]
+         options: [type: :bloom_filter, granularity: 8126]
        )}
 
     assert execute_ddl(create) == [
              """
-             CREATE INDEX "posts$main" \
-             ON "posts" (lower(permalink)) \
-             TYPE range GRANULARITY 8126\
+             ALTER TABLE "posts" \
+             ADD INDEX "posts$main" (lower(permalink)) \
+             TYPE bloom_filter GRANULARITY 8126\
              """
            ]
   end
@@ -2219,13 +2221,15 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
   test "create index if not exists" do
     create =
       {:create_if_not_exists,
-       index(:posts, [:category_id, :permalink], options: [type: :range, granularity: 8126])}
+       index(:posts, [:category_id, :permalink],
+         options: [type: :bloom_filter, granularity: 8126]
+       )}
 
     assert execute_ddl(create) == [
              """
-             CREATE INDEX IF NOT EXISTS "posts_category_id_permalink_index" \
-             ON "posts" ("category_id","permalink") \
-             TYPE range GRANULARITY 8126\
+             ALTER TABLE "posts" \
+             ADD INDEX IF NOT EXISTS "posts_category_id_permalink_index" ("category_id","permalink") \
+             TYPE bloom_filter GRANULARITY 8126\
              """
            ]
   end
@@ -2235,14 +2239,14 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
       {:create,
        index(:posts, [:category_id, :permalink],
          prefix: :foo,
-         options: [type: :range, granularity: 8126]
+         options: [type: :bloom_filter, granularity: 8126]
        )}
 
     assert execute_ddl(create) == [
              """
-             CREATE INDEX "posts_category_id_permalink_index" \
-             ON "foo"."posts" ("category_id","permalink") \
-             TYPE range GRANULARITY 8126\
+             ALTER TABLE "foo"."posts" \
+             ADD INDEX "posts_category_id_permalink_index" ("category_id","permalink") \
+             TYPE bloom_filter GRANULARITY 8126\
              """
            ]
 
@@ -2251,14 +2255,14 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
        index(:posts, ["lower(permalink)"],
          name: "posts$main",
          prefix: :foo,
-         options: [type: :range, granularity: 8126]
+         options: [type: :bloom_filter, granularity: 8126]
        )}
 
     assert execute_ddl(create) == [
              """
-             CREATE INDEX "posts$main" \
-             ON "foo"."posts" (lower(permalink)) \
-             TYPE range GRANULARITY 8126\
+             ALTER TABLE "foo"."posts" \
+             ADD INDEX "posts$main" (lower(permalink)) \
+             TYPE bloom_filter GRANULARITY 8126\
              """
            ]
   end
@@ -2270,14 +2274,14 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
        index(:posts, [:category_id, :permalink],
          prefix: :foo,
          comment: "comment",
-         options: [type: :range, granularity: 8126]
+         options: [type: :bloom_filter, granularity: 8126]
        )}
 
     assert execute_ddl(create) == [
              """
-             CREATE INDEX "posts_category_id_permalink_index" \
-             ON "foo"."posts" ("category_id","permalink") \
-             TYPE range GRANULARITY 8126\
+             ALTER TABLE "foo"."posts" \
+             ADD INDEX "posts_category_id_permalink_index" ("category_id","permalink") \
+             TYPE bloom_filter GRANULARITY 8126\
              """
            ]
   end
@@ -2316,13 +2320,16 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
   test "create index concurrently" do
     create =
       {:create,
-       index(:posts, [:permalink], concurrently: true, options: [type: :range, granularity: 8126])}
+       index(:posts, [:permalink],
+         concurrently: true,
+         options: [type: :bloom_filter, granularity: 8126]
+       )}
 
     assert execute_ddl(create) == [
              """
-             CREATE INDEX "posts_permalink_index" \
-             ON "posts" ("permalink") \
-             TYPE range GRANULARITY 8126\
+             ALTER TABLE "posts" \
+             ADD INDEX "posts_permalink_index" ("permalink") \
+             TYPE bloom_filter GRANULARITY 8126\
              """
            ]
   end
@@ -2343,8 +2350,8 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
 
     assert execute_ddl(create) == [
              """
-             CREATE INDEX "posts_permalink_index" \
-             ON "posts" ("permalink") \
+             ALTER TABLE "posts" \
+             ADD INDEX "posts_permalink_index" ("permalink") \
              TYPE range GRANULARITY 8126\
              """
            ]

--- a/test/ecto/adapters/clickhouse/migration_test.exs
+++ b/test/ecto/adapters/clickhouse/migration_test.exs
@@ -1,0 +1,100 @@
+defmodule Ecto.Adapters.ClickHouse.MigrationTest do
+  use ExUnit.Case
+
+  alias Ecto.Adapters.ClickHouse
+
+  defmodule MigrationRepo do
+    use Ecto.Repo, adapter: Ecto.Adapters.ClickHouse, otp_app: :migration_test
+  end
+
+  defmodule Table do
+    use Ecto.Migration
+
+    def change do
+      create table("events",
+               primary_key: false,
+               engine: "MergeTree",
+               options:
+                 "PARTITION BY toYYYYMM(timestamp) ORDER BY (domain, toDate(timestamp), user_id) SETTINGS index_granularity = 8192"
+             ) do
+        add :name, :string
+        add :domain, :string
+        add :user_id, :UInt64
+        add :session_id, :UInt64
+        add :hostname, :string
+        add :pathname, :string
+        add :referrer, :string
+        add :referrer_source, :string
+        add :country_code, :"LowCardinality(FixedString(2))"
+        add :screen_size, :"LowCardinality(String)"
+        add :operating_system, :"LowCardinality(String)"
+        add :browser, :"LowCardinality(String)"
+        add :timestamp, :naive_datetime
+      end
+    end
+  end
+
+  defmodule Index do
+    use Ecto.Migration
+
+    def change do
+      create index(:events, [:name], options: [type: :bloom_filter, granularity: 8192])
+    end
+  end
+
+  test "events (table+index)" do
+    database = "ecto_ch_migration_test_events"
+    opts = [database: database]
+
+    assert :ok = ClickHouse.storage_up(opts)
+    on_exit(fn -> ClickHouse.storage_down(opts) end)
+
+    Application.put_env(:migration_test, MigrationRepo,
+      database: database,
+      show_sensitive_data_on_connection_error: true
+    )
+
+    on_exit(fn -> Application.delete_env(:migration_test, MigrationRepo) end)
+
+    start_supervised!(MigrationRepo)
+
+    assert [1, 2] ==
+             Ecto.Migrator.run(MigrationRepo, [{1, Table}, {2, Index}], :up,
+               all: true,
+               log: false
+             )
+
+    conn = start_supervised!({Ch, opts})
+
+    assert Ch.query!(
+             conn,
+             "select create_table_query from system.tables where database = {database:String} and table = {table:String}",
+             %{"database" => database, "table" => "events"}
+           ).rows == [
+             [
+               """
+               CREATE TABLE ecto_ch_migration_test_events.events (\
+               `name` String, \
+               `domain` String, \
+               `user_id` UInt64, \
+               `session_id` UInt64, \
+               `hostname` String, \
+               `pathname` String, \
+               `referrer` String, \
+               `referrer_source` String, \
+               `country_code` LowCardinality(FixedString(2)), \
+               `screen_size` LowCardinality(String), \
+               `operating_system` LowCardinality(String), \
+               `browser` LowCardinality(String), \
+               `timestamp` DateTime, \
+               INDEX events_name_index name TYPE bloom_filter GRANULARITY 8192\
+               ) \
+               ENGINE = MergeTree \
+               PARTITION BY toYYYYMM(timestamp) \
+               ORDER BY (domain, toDate(timestamp), user_id) \
+               SETTINGS index_granularity = 8192\
+               """
+             ]
+           ]
+  end
+end


### PR DESCRIPTION
Even though the previous syntax works, I couldn't fine documentation for it on https://clickhouse.com/docs/en/sql-reference/statements/create

The new syntax is documented here https://clickhouse.com/docs/en/sql-reference/statements/alter/skipping-index