### PR TITLE
add :default_table_options option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - raise on `CREATE INDEX CONCURRENTLY` https://github.com/plausible/ecto_ch/pull/121
 - switch from `DROP INDEX` to `ALTER TABLE ... DROP INDEX` syntax for indexes https://github.com/plausible/ecto_ch/pull/122
 - add support for structured `:options` in migrations https://github.com/plausible/ecto_ch/pull/116
+- add `:default_table_engine` option https://github.com/plausible/ecto_ch/pull/123
 
 ## 0.2.2 (2023-08-29)
 

--- a/README.md
+++ b/README.md
@@ -34,10 +34,12 @@ defmodule MyApp.Repo do
 end
 ```
 
-Optionally you can also set the default table engine to use in migrations
+Optionally you can also set the default table engine and options to use in migrations
 
 ```elixir
-config :ecto_ch, default_table_engine: "TinyLog"
+config :ecto_ch,
+  default_table_engine: "TinyLog",
+  default_table_options: [cluster: "little-giant", order_by: "tuple()"]
 ```
 
 #### Ecto schemas


### PR DESCRIPTION
This PR adds `:default_table_options` mostly as a way to pass options to `:schema_migrations` table migration.

Relevant discussion: https://github.com/plausible/ecto_ch/pull/115#issuecomment-1716040253