### PR TITLE
allow map params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- allow `Map(K,V)` params https://github.com/plausible/ecto_ch/pull/155
+
 ## 0.3.2 (2023-12-19)
 
 - use DateTime64 for usec timestamps https://github.com/plausible/ecto_ch/pull/142

--- a/lib/ecto/adapters/clickhouse/connection.ex
+++ b/lib/ecto/adapters/clickhouse/connection.ex
@@ -931,4 +931,21 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
 
   # TODO check whole list
   defp param_type([v | _]), do: ["Array(", param_type(v), ?)]
+
+  defp param_type(%s{}) do
+    raise ArgumentError, "struct #{inspect(s)} is not supported in params"
+  end
+
+  defp param_type(m) when is_map(m) do
+    case Map.keys(m) do
+      # TODO check whole list
+      [k | _] ->
+        # TODO check whole list
+        [v | _] = Map.values(m)
+        ["Map(", param_type(k), ?,, param_type(v), ?)]
+
+      [] ->
+        "Map(Nothing,Nothing)"
+    end
+  end
 end

--- a/test/ecto/adapters/clickhouse/connection_test.exs
+++ b/test/ecto/adapters/clickhouse/connection_test.exs
@@ -2656,6 +2656,14 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
     assert all(query) == ~s{SELECT [1,2,3] FROM "schema" AS s0}
   end
 
+  test "maps" do
+    assert all(select(Schema, [], fragment("?[site_id]", ^%{}))) ==
+             ~s|SELECT {$0:Map(Nothing,Nothing)}[site_id] FROM "schema" AS s0|
+
+    assert all(select(Schema, [], fragment("?[site_id]", ^%{1 => "UTC"}))) ==
+             ~s|SELECT {$0:Map(Int64,String)}[site_id] FROM "schema" AS s0|
+  end
+
   test "preloading" do
     query = from(p in Post, preload: [:comments], select: p)
 


### PR DESCRIPTION
This PR allows passing map as params, e.g.

```elixir
site_ids = [1, 2, 3]
site_ids_with_tzs = %{1 => "UTC", 2 => "Europe/Vienna", 3 => "Asia/Taipei"}

from e in "events",
  where: e.site_id in ^site_ids and e.timestamp >= ^0 and e.timestamp <= ^1,
  group_by: [e.site_id, selected_as(:bucket)],
  select: %{
    site_id: e.site_id,
    bucket: selected_as(fragment("toStartOfHour(toTimeZone(timestamp, ?[site_id]))", ^site_ids_with_tzs), :bucket),
    count: fragment("count()")
  }
```