### PR TITLE
express ARRAY JOIN via hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- deprecate `:array_join` and support ARRAY join hint
+
 ## 0.3.5 (2024-05-01)
 
 - add `to_inline_sql/2` which is similar to `to_sql/2` but inlines the parameters into SQL https://github.com/plausible/ecto_ch/pull/157

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- deprecate `:array_join` and support ARRAY join hint
+- deprecate `:array_join` and support ARRAY join hint https://github.com/plausible/ecto_ch/pull/160
 
 ## 0.3.5 (2024-05-01)
 

--- a/README.md
+++ b/README.md
@@ -125,25 +125,7 @@ CREATE TABLE `posts` ON CLUSTER `my-cluster` (
 
 #### [ARRAY JOIN](https://clickhouse.com/docs/en/sql-reference/statements/select/array-join)
 
-Since [`v3.10.2`](https://github.com/elixir-ecto/ecto/blob/40133ace8c71f1f81432858e71d3d73527f85107/CHANGELOG.md?plain=1#L10) Ecto supports `:array` and `:left_array` join types:
-
-```elixir
-from a in "arrays_test", array_join: r in "arr", select: {a.s, fragment("?", r)}
-```
-
-For an earlier Ecto version `:inner_lateral` and `:left_lateral` join types can be used instead:
-
-```elixir
-from a in "arrays_test", inner_lateral_join: r in "arr", select: {a.s, fragment("?", r)}
-```
-
-Both of these queries are equivalent to:
-
-```sql
-SELECT a0."s", a1 FROM "arrays_test" AS a0 ARRAY JOIN "arr" AS a1
-```
-
-For more `ARRAY JOIN` examples and other ClickHouse-specific JOIN types please see [clickhouse_joins_test.exs.](./test/ecto/integration/clickhouse_joins_test.exs)
+For `ARRAY JOIN` examples and other ClickHouse-specific JOIN types please see [clickhouse_joins_test.exs.](./test/ecto/integration/clickhouse_joins_test.exs)
 
 #### NULL
 

--- a/lib/ecto/adapters/clickhouse/connection.ex
+++ b/lib/ecto/adapters/clickhouse/connection.ex
@@ -249,6 +249,7 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
 
   defp select_fields(fields, sources, params, query) do
     intersperse_map(fields, ?,, fn
+      # TODO raise
       # this is useful in array joins lie
       #
       #     "arrays_test"

--- a/test/ecto/adapters/clickhouse/connection_test.exs
+++ b/test/ecto/adapters/clickhouse/connection_test.exs
@@ -1315,6 +1315,7 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
              """
   end
 
+  @tag :capture_log
   test "lateral (but really array) join" do
     query =
       "arrays_test"
@@ -1326,6 +1327,7 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
            """
   end
 
+  @tag :capture_log
   test "left lateral (but really left array) join" do
     query =
       "arrays_test"
@@ -1337,6 +1339,7 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
            """
   end
 
+  @tag :capture_log
   test "array join" do
     query =
       from at in "arrays_test",
@@ -1346,8 +1349,20 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
     assert all(query) == """
            SELECT a0."s",a1 FROM "arrays_test" AS a0 ARRAY JOIN "arr" AS a1\
            """
+
+    assert all(
+             from at in "arrays_test",
+               join: a in "arr",
+               on: true,
+               hints: "ARRAY",
+               select: [at.s, a]
+           ) ==
+             """
+             SELECT a0."s",a1 FROM "arrays_test" AS a0 ARRAY JOIN "arr" AS a1\
+             """
   end
 
+  @tag :capture_log
   test "left array join" do
     query =
       from at in "arrays_test",
@@ -1357,6 +1372,17 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
     assert all(query) == """
            SELECT a0."s",a1 FROM "arrays_test" AS a0 LEFT ARRAY JOIN "arr" AS a1\
            """
+
+    assert all(
+             from at in "arrays_test",
+               left_join: a in "arr",
+               on: true,
+               hints: "ARRAY",
+               select: [at.s, a]
+           ) ==
+             """
+             SELECT a0."s",a1 FROM "arrays_test" AS a0 LEFT ARRAY JOIN "arr" AS a1\
+             """
   end
 
   test "join with nothing bound" do
@@ -1845,7 +1871,7 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
 
     test "invalid type" do
       expected_message =
-        ~r/unsupported JOIN strictness passed in hints: \["INVALID"\]\nsupported: "ASOF", "ANY", "ANTI", "SEMI"/
+        ~r/unsupported JOIN strictness or type passed in hints: \["INVALID"\]\nsupported: "ASOF", "ANY", "ANTI", "SEMI", "ARRAY"/
 
       assert_raise Ecto.QueryError, expected_message, fn ->
         all(


### PR DESCRIPTION
This PR removes the need for special `:array_join` keyword in Ecto.