### PR TITLE
fix datetime64 parsing

### DIFF
--- a/lib/ecto/adapters/clickhouse/connection.ex
+++ b/lib/ecto/adapters/clickhouse/connection.ex
@@ -1109,7 +1109,15 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
   defp param_type(b) when is_boolean(b), do: "Bool"
 
   # TODO Date32
-  defp param_type(%NaiveDateTime{}), do: "DateTime"
+  defp param_type(%NaiveDateTime{microsecond: microsecond} = datetime) do
+    case microsecond do
+      {_val, precision} when precision > 0 ->
+        ["DateTime64(", Integer.to_string(precision), ?)]
+
+      _ ->
+        "DateTime"
+    end
+  end
 
   defp param_type(%DateTime{microsecond: microsecond}) do
     case microsecond do

--- a/test/ecto/adapters/clickhouse/connection_test.exs
+++ b/test/ecto/adapters/clickhouse/connection_test.exs
@@ -22,6 +22,7 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
     schema "posts" do
       field(:title, :string)
       field(:content, :string)
+      field(:timestamp, Ch, type: "DateTime64(3)")
       has_many(:comments, Comment)
     end
   end
@@ -3023,7 +3024,8 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
   test "preloading" do
     query = from(p in Post, preload: [:comments], select: p)
 
-    assert all(query) == ~s{SELECT p0."id",p0."title",p0."content" FROM "posts" AS p0}
+    assert all(query) ==
+             ~s{SELECT p0."id",p0."title",p0."content",p0."timestamp" FROM "posts" AS p0}
   end
 
   test "autoincrement support" do
@@ -3094,6 +3096,14 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
                select: e.timestamp
            ) == """
            SELECT e0."timestamp" FROM "events" AS e0 WHERE (e0."timestamp" > {$0:DateTime64(6)})\
+           """
+
+    assert all(
+             from p in Post,
+               where: p.timestamp > ^~U[2024-06-28 20:02:17.382Z],
+               select: p.timestamp
+           ) == """
+           SELECT p0."timestamp" FROM "posts" AS p0 WHERE (p0."timestamp" > {$0:DateTime64(3)})\
            """
   end
 


### PR DESCRIPTION
This is a PR to fix DateTime64 when defined in the schema as: 

```
 field(:timestamp, Ch, type: "DateTime64(3)")
```

This is what is happening afaik:

- dumper returns `:naive_datetime_usec` [here](https://github.com/plausible/ecto_ch/blob/master/lib/ecto/adapters/clickhouse.ex#L175) 
- ecto transforms the given DateTime as NaiveDateTime [here](https://github.com/elixir-ecto/ecto/blob/master/lib/ecto/type.ex#L711) 

The code I changed in `ecto_ch` returns `DateTime` as `param_type` instead of `DateTime64(<precision>)`

My test suite is erroring (without this fix) with:

```
  ** (Ch.Error) Code: 457. DB::Exception: Value 2024-08-14T20:55:30.094116 cannot be parsed as DateTime for query parameter '$1' because it isn't parsed completely: only 19 of 26 bytes was parsed: 2024-08-14T20:55:30. (BAD_QUERY_PARAMETER) (version 23.12.1.1368 (official build))
```

I added a test that raises a similar error and fixed it with a very similar code change that was recently introduced to support DateTime64