### PR TITLE
fewer parens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- remove some unnecessary parens from generated SQL to avoid hitting TOO_DEEP_RECURSION https://github.com/plausible/ecto_ch/pull/207
+
 ## 0.4.0 (2024-10-15)
 
 - use `UNION DISTINCT` instead of `UNION` for `Ecto.Query.union/2` https://github.com/plausible/ecto_ch/pull/204


### PR DESCRIPTION
Context: https://github.com/plausible/analytics/commit/6399cf54318c40434dd3686df253ab09ef4d3c3c

Preview: https://github.com/plausible/analytics/pull/4769

<details><summary>ast before this PR</summary>

```sql
0cdf854b7d84 :) explain ast SELECT 1 FROM values((1)) WHERE ((((((((1 AND 1) AND 1) AND 1) AND 1) AND 1) AND 1) AND 1) AND 1);

EXPLAIN AST
SELECT 1
FROM values(1)
WHERE (((((((1 AND 1) AND 1) AND 1) AND 1) AND 1) AND 1) AND 1) AND 1

Query id: 3bd5dd60-a3d0-410c-9ca2-50d0c10eb1b9

    ┌─explain───────────────────────────────────────┐
 1. │ SelectWithUnionQuery (children 1)             │
 2. │  ExpressionList (children 1)                  │
 3. │   SelectQuery (children 3)                    │
 4. │    ExpressionList (children 1)                │
 5. │     Literal UInt64_1                          │
 6. │    TablesInSelectQuery (children 1)           │
 7. │     TablesInSelectQueryElement (children 1)   │
 8. │      TableExpression (children 1)             │
 9. │       Function values (children 1)            │
10. │        ExpressionList (children 1)            │
11. │         Literal UInt64_1                      │
12. │    Function and (children 1)                  │
13. │     ExpressionList (children 2)               │
14. │      Function and (children 1)                │
15. │       ExpressionList (children 2)             │
16. │        Function and (children 1)              │
17. │         ExpressionList (children 2)           │
18. │          Function and (children 1)            │
19. │           ExpressionList (children 2)         │
20. │            Function and (children 1)          │
21. │             ExpressionList (children 2)       │
22. │              Function and (children 1)        │
23. │               ExpressionList (children 2)     │
24. │                Function and (children 1)      │
25. │                 ExpressionList (children 2)   │
26. │                  Function and (children 1)    │
27. │                   ExpressionList (children 2) │
28. │                    Literal UInt64_1           │
29. │                    Literal UInt64_1           │
30. │                  Literal UInt64_1             │
31. │                Literal UInt64_1               │
32. │              Literal UInt64_1                 │
33. │            Literal UInt64_1                   │
34. │          Literal UInt64_1                     │
35. │        Literal UInt64_1                       │
36. │      Literal UInt64_1                         │
    └───────────────────────────────────────────────┘
```

</details>

<details><summary>ast after this pr</summary>

```sql
0cdf854b7d84 :) explain ast SELECT 1 FROM values((1)) WHERE 1 AND 1 AND 1 AND 1 AND 1 AND 1 AND 1 AND 1 AND 1;

EXPLAIN AST
SELECT 1
FROM values(1)
WHERE 1 AND 1 AND 1 AND 1 AND 1 AND 1 AND 1 AND 1 AND 1

Query id: 4939be02-0611-4d8b-a24f-79e9c5831ee7

    ┌─explain─────────────────────────────────────┐
 1. │ SelectWithUnionQuery (children 1)           │
 2. │  ExpressionList (children 1)                │
 3. │   SelectQuery (children 3)                  │
 4. │    ExpressionList (children 1)              │
 5. │     Literal UInt64_1                        │
 6. │    TablesInSelectQuery (children 1)         │
 7. │     TablesInSelectQueryElement (children 1) │
 8. │      TableExpression (children 1)           │
 9. │       Function values (children 1)          │
10. │        ExpressionList (children 1)          │
11. │         Literal UInt64_1                    │
12. │    Function and (children 1)                │
13. │     ExpressionList (children 9)             │
14. │      Literal UInt64_1                       │
15. │      Literal UInt64_1                       │
16. │      Literal UInt64_1                       │
17. │      Literal UInt64_1                       │
18. │      Literal UInt64_1                       │
19. │      Literal UInt64_1                       │
20. │      Literal UInt64_1                       │
21. │      Literal UInt64_1                       │
22. │      Literal UInt64_1                       │
    └─────────────────────────────────────────────┘
```

</details>

---

This PR tries to keep changes minimal, so there is another PR that completely removes unnecessary parens: https://github.com/plausible/ecto_ch/pull/209 (to be merged later)