### PR TITLE
better statement splitter

### DIFF
--- a/lib/ecto/adapters/clickhouse/structure.ex
+++ b/lib/ecto/adapters/clickhouse/structure.ex
@@ -12,9 +12,7 @@ defmodule Ecto.Adapters.ClickHouse.Structure do
          {:ok, queries} <- File.read(path) do
       multiquery_result =
         queries
-        |> String.split(";", trim: true)
-        |> Enum.map(&String.trim/1)
-        |> Enum.reject(&(&1 == ""))
+        |> @conn.extract_statements()
         |> Enum.reduce_while({:ok, _prev_result = nil, conn}, fn
           query, {:ok, _prev_result, conn} -> {:cont, exec(conn, query)}
           _query, {:error, _reason} = error -> {:halt, error}

--- a/test/ecto/adapters/clickhouse/extract_statements_test.exs
+++ b/test/ecto/adapters/clickhouse/extract_statements_test.exs
@@ -25,8 +25,12 @@ defmodule Ecto.Adapters.ClickHouse.ExtractStatementsTest do
     assert extract_statements("select '`a; b`'; select 2;") == ["select '`a; b`'", "select 2"]
     assert extract_statements("select '`a`; `b`'; select 2;") == ["select '`a`; `b`'", "select 2"]
 
-    assert extract_statements("select 'DO NOT RUN THIS: \\'; drop table events\\''") == [
+    # sanity check
+    assert ~S[select 'DO NOT RUN THIS: \'; drop table events\''] ==
              "select 'DO NOT RUN THIS: \\'; drop table events\\''"
+
+    assert extract_statements(~S[select 'DO NOT RUN THIS: \'; drop table events\'']) == [
+             ~S[select 'DO NOT RUN THIS: \'; drop table events\'']
            ]
 
     assert extract_statements("select `funny_columns;`; select 2;") == [

--- a/test/ecto/adapters/clickhouse/extract_statements_test.exs
+++ b/test/ecto/adapters/clickhouse/extract_statements_test.exs
@@ -25,6 +25,10 @@ defmodule Ecto.Adapters.ClickHouse.ExtractStatementsTest do
     assert extract_statements("select '`a; b`'; select 2;") == ["select '`a; b`'", "select 2"]
     assert extract_statements("select '`a`; `b`'; select 2;") == ["select '`a`; `b`'", "select 2"]
 
+    assert extract_statements("select 'DO NOT RUN THIS: \\'; drop table events\\''") == [
+             "select 'DO NOT RUN THIS: \\'; drop table events\\''"
+           ]
+
     assert extract_statements("select `funny_columns;`; select 2;") == [
              "select `funny_columns;`",
              "select 2"

--- a/test/ecto/adapters/clickhouse/extract_statements_test.exs
+++ b/test/ecto/adapters/clickhouse/extract_statements_test.exs
@@ -1,0 +1,64 @@
+defmodule Ecto.Adapters.ClickHouse.ExtractStatementsTest do
+  use ExUnit.Case, async: true
+  import Ecto.Adapters.ClickHouse.Connection, only: [extract_statements: 1]
+
+  test "extract_statements/1" do
+    assert extract_statements("") == []
+
+    assert extract_statements("select 1") == ["select 1"]
+    assert extract_statements("select 1;") == ["select 1"]
+
+    assert extract_statements("select 1; select 2") == ["select 1", "select 2"]
+    assert extract_statements("select 1; select 2;") == ["select 1", "select 2"]
+    assert extract_statements("select 1;; select 2;") == ["select 1", "select 2"]
+    assert extract_statements("select 1; ; select 2;") == ["select 1", "select 2"]
+    assert extract_statements("select 1; ; select 2 ;") == ["select 1", "select 2"]
+    assert extract_statements("select 1; ; select 2; ;") == ["select 1", "select 2"]
+
+    assert extract_statements("select 1; select 2; select 3;") == [
+             "select 1",
+             "select 2",
+             "select 3"
+           ]
+
+    assert extract_statements("select 'a; b'; select 2;") == ["select 'a; b'", "select 2"]
+    assert extract_statements("select '`a; b`'; select 2;") == ["select '`a; b`'", "select 2"]
+    assert extract_statements("select '`a`; `b`'; select 2;") == ["select '`a`; `b`'", "select 2"]
+
+    assert extract_statements("select `funny_columns;`; select 2;") == [
+             "select `funny_columns;`",
+             "select 2"
+           ]
+
+    assert extract_statements("select \"funny_columns;\"; select 2;") == [
+             "select \"funny_columns;\"",
+             "select 2"
+           ]
+
+    assert extract_statements("""
+           -- imagine a comment here and it's ; select 'YOLO'; drop table events
+           select 1; -- imagine a comment here too; select 'YOLO x2'; drop table events_v2
+
+           select 2;
+           """) == [
+             """
+             -- imagine a comment here and it's ; select 'YOLO'; drop table events
+             select 1\
+             """,
+             """
+             -- imagine a comment here too; select 'YOLO x2'; drop table events_v2
+
+             select 2\
+             """
+           ]
+
+    assert extract_statements("""
+           select 1;
+           select 2 -- unterminated ;;;;;;; comment;
+           """) == ["select 1", "select 2 -- unterminated ;;;;;;; comment;"]
+
+    assert extract_statements("""
+           select /* comment; another /* comment within; comment */ */ 1; select 2;
+           """) == ["select /* comment; another /* comment within; comment */ */ 1", "select 2"]
+  end
+end


### PR DESCRIPTION
Preparing for https://hexdocs.pm/ecto_sql/Ecto.Adapters.SQL.html#query_many/4

Context: https://github.com/plausible/analytics/pull/4701#discussion_r1830895355

TODOs:
- https://clickhouse.com/docs/en/sql-reference/syntax#heredoc
- https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html
- more tests
- copy some of stateless ClickHouse parser tests?
- property tests? with "random" quote / comment / semicolon injection

```elixir
check all(statements <- gen_statements()) do
  assert extract_statements(Enum.join(statements, ";")) == statements
  # and maybe execute them in ClickHouse
end

defp gen_statements do
  for str <- string(:printable) do
    "select '#{str}'"
  end
  
  # etc. and union them all
end
```