### PR TITLE
Remove dependabot for Elixir dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,6 @@
 
 version: 2
 updates:
-  - package-ecosystem: "mix"
-    directory: "/"
-    schedule:
-      interval: "daily"
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Too noisy. And since the dependencies are resolved downstream our mix.lock doesn't matter.