### PR TITLE
Remove docs link to Ecto.Repo.update_all

### DIFF
--- a/lib/ecto/adapters/clickhouse.ex
+++ b/lib/ecto/adapters/clickhouse.ex
@@ -119,7 +119,7 @@ defmodule Ecto.Adapters.ClickHouse do
       end
 
       @doc """
-      Similar to Ecto.Repo.update_all/3 but uses [`ALTER TABLE ... UPDATE`](https://clickhouse.com/docs/en/sql-reference/statements/alter/update) instead.
+      Similar to `c:Ecto.Repo.update_all/3` but uses [`ALTER TABLE ... UPDATE`](https://clickhouse.com/docs/en/sql-reference/statements/alter/update) instead.
 
       For more information and performance implications please see:
 

--- a/lib/ecto/adapters/clickhouse.ex
+++ b/lib/ecto/adapters/clickhouse.ex
@@ -119,7 +119,7 @@ defmodule Ecto.Adapters.ClickHouse do
       end
 
       @doc """
-      Similar to `Ecto.Repo.update_all/3` but uses [`ALTER TABLE ... UPDATE`](https://clickhouse.com/docs/en/sql-reference/statements/alter/update) instead.
+      Similar to Ecto.Repo.update_all/3 but uses [`ALTER TABLE ... UPDATE`](https://clickhouse.com/docs/en/sql-reference/statements/alter/update) instead.
 
       For more information and performance implications please see:
 


### PR DESCRIPTION
Simply removes the code link to `Ecto.Repo.update_all` because that is not a function that actually exists and it causes a warning when generating docs.

As part of my company's project we generate docs for our app and all deps to host for devs. This is part of an effort to remove all warnings from that process.

I.E.
```
> mix docs
Compiling 2 files (.ex)
Generated ecto_ch app
Generating docs...
    warning: documentation references function "Ecto.Repo.update_all/3" but it is undefined or private
    │
  2 │   use Ecto.Repo,
    │   ~~~~~~~~~~~~~~
    │
    └─ (ecto_ch 0.6.0) dev/repo.ex:2: Dev.Repo.alter_update_all/3

View "html" docs at "doc/index.html"
    warning: documentation references function "Ecto.Repo.update_all/3" but it is undefined or private
    │
  2 │   use Ecto.Repo,
    │   ~~~~~~~~~~~~~~
    │
    └─ (ecto_ch 0.6.0) dev/repo.ex:2: Dev.Repo.alter_update_all/3

View "epub" docs at "doc/Ecto ClickHouse.epub"
```

After this PR:
```
> mix docs
Compiling 2 files (.ex)
Generated ecto_ch app
Generating docs...
View "html" docs at "doc/index.html"
View "epub" docs at "doc/Ecto ClickHouse.epub" 
```