### PR TITLE
Filter by `currentDatabase()` in `table_exists_query`

### DIFF
--- a/lib/ecto/adapters/clickhouse/connection.ex
+++ b/lib/ecto/adapters/clickhouse/connection.ex
@@ -207,7 +207,8 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
 
   @impl true
   def table_exists_query(table) do
-    {"SELECT name FROM system.tables WHERE name={$0:String} AND database=currentDatabase() LIMIT 1", [table]}
+    {"SELECT name FROM system.tables WHERE name={$0:String} AND database=currentDatabase() LIMIT 1",
+     [table]}
   end
 
   @impl true

--- a/lib/ecto/adapters/clickhouse/connection.ex
+++ b/lib/ecto/adapters/clickhouse/connection.ex
@@ -207,7 +207,7 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
 
   @impl true
   def table_exists_query(table) do
-    {"SELECT name FROM system.tables WHERE name={$0:String} LIMIT 1", [table]}
+    {"SELECT name FROM system.tables WHERE name={$0:String} AND database=currentDatabase() LIMIT 1", [table]}
   end
 
   @impl true


### PR DESCRIPTION
👋 I've stumbled upon an issue where running `mix ecto.load` on a test database always warns that the structure is already loaded. The query used in `table_exists_query` does not filter by database. If there's any other database on the same ClickHouse instance (for dev env, for instance), this query can falsely return positive. While the database is not available within that function, `currentDatabase()` should return the currently used database. `currentDatabase()` had some issues related to clustered setups in the past but those seem to be fixed by now. WDYT @ruslandoga ?