### PR TITLE
Support Ecto time types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Raise when combination queries have a parent `LIMIT` or `OFFSET` and direct callers to wrap the combination in `subquery/1` https://github.com/plausible/ecto_ch/pull/301
 - Escape double quotes, backticks, and backslashes in quoted ClickHouse identifiers https://github.com/plausible/ecto_ch/pull/283
+- Support Ecto `:time` and `:time_usec` types as ClickHouse `Time` and `Time64(6)` https://github.com/plausible/ecto_ch/pull/242
 
 ## 0.11.0 (2026-08-08)
 

--- a/lib/ecto/adapters/clickhouse/connection.ex
+++ b/lib/ecto/adapters/clickhouse/connection.ex
@@ -1132,9 +1132,11 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
   defp ecto_to_db({:parameterized, {Ch, type}}, _query), do: Ch.Types.encode(type)
   defp ecto_to_db({:array, type}, query), do: ["Array(", ecto_to_db(type, query), ?)]
 
-  defp ecto_to_db(type, _query) when type in [:uuid, :string, :date, :boolean] do
+  defp ecto_to_db(type, _query) when type in [:uuid, :string, :date, :time, :boolean] do
     Ch.Types.encode(type)
   end
+
+  defp ecto_to_db(:time_usec, _query), do: Ch.Types.encode({:time64, 6})
 
   defp ecto_to_db(type, query) do
     raise Ecto.QueryError,
@@ -1199,6 +1201,11 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
     [?', Date.to_string(date), suffix]
   end
 
+  defp inline_param(%Time{microsecond: {_value, precision}} = time) do
+    type = if precision > 0, do: ["Time64(", Integer.to_string(precision), ?)], else: "Time"
+    [?', Time.to_string(time), "'::", type]
+  end
+
   defp inline_param(%Decimal{} = dec), do: decimal_to_string(dec)
 
   defp inline_param(a) when is_list(a) do
@@ -1253,6 +1260,12 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
 
   # TODO Date32
   defp param_type(%Date{}), do: "Date"
+
+  defp param_type(%Time{microsecond: {_value, precision}}) when precision > 0 do
+    ["Time64(", Integer.to_string(precision), ?)]
+  end
+
+  defp param_type(%Time{}), do: "Time"
 
   defp param_type(%Decimal{} = decimal) do
     {precision, scale} = decimal_precision_and_scale!(decimal)

--- a/lib/ecto/adapters/clickhouse/migration.ex
+++ b/lib/ecto/adapters/clickhouse/migration.ex
@@ -439,10 +439,6 @@ defmodule Ecto.Adapters.ClickHouse.Migration do
     raise ArgumentError, "type :numeric is not supported"
   end
 
-  defp column_type(:time) do
-    raise ArgumentError, "type :time is not supported"
-  end
-
   defp column_type(:map) do
     raise ArgumentError,
           ~s[type :map is ambiguous, use a literal (e.g. :JSON or :"Map(String, UInt8)") instead]
@@ -463,6 +459,9 @@ defmodule Ecto.Adapters.ClickHouse.Migration do
   end
 
   defp column_type(:float), do: "Float64"
+
+  defp column_type(:time), do: "Time"
+  defp column_type(:time_usec), do: "Time64(6)"
 
   defp column_type({:array, type}) do
     ["Array(", column_type(type), ?)]

--- a/lib/ecto/adapters/clickhouse/schema.ex
+++ b/lib/ecto/adapters/clickhouse/schema.ex
@@ -271,7 +271,7 @@ defmodule Ecto.Adapters.ClickHouse.Schema do
   end
 
   defp remap_type(t, _original, _schema, _field)
-       when t in [:string, :date, :uuid, :boolean],
+       when t in [:string, :date, :time, :uuid, :boolean],
        do: t
 
   defp remap_type(Ecto.UUID, _original, _schema, _field), do: :uuid
@@ -283,6 +283,8 @@ defmodule Ecto.Adapters.ClickHouse.Schema do
   defp remap_type(usec, _original, _schema, _field)
        when usec in [:naive_datetime_usec, :utc_datetime_usec],
        do: {:datetime64, _precision = 6}
+
+  defp remap_type(:time_usec, _original, _schema, _field), do: {:time64, _precision = 6}
 
   # TODO remove
   defp remap_type(t, _original, _schema, _field)
@@ -299,11 +301,6 @@ defmodule Ecto.Adapters.ClickHouse.Schema do
     do: {a, remap_type(t, original, schema, field)}
 
   defp remap_type(:integer, _original, Ecto.Migration.SchemaMigration, :version), do: :i64
-
-  defp remap_type(time, _original, _schema, _field) when time in [:time, :time_usec] do
-    raise ArgumentError,
-          "`#{inspect(time)}` type is not supported as there is no `Time` type in ClickHouse."
-  end
 
   defp remap_type(type, original, schema, field) do
     case Ecto.Type.type(type) do

--- a/test/ch/type_test.exs
+++ b/test/ch/type_test.exs
@@ -511,6 +511,82 @@ defmodule Ch.TypeTest do
     end
   end
 
+  describe "Time / Time64" do
+    @describetag :time
+
+    setup do
+      query!("""
+      create table ch_times (
+        ch_time Time,
+        ch_time64 Time64(3),
+        time Time,
+        time_usec Time64(6)
+      ) engine Memory
+      """)
+
+      on_exit(fn -> query!("truncate ch_times") end)
+    end
+
+    defmodule Times do
+      use Ecto.Schema
+
+      @primary_key false
+      schema "ch_times" do
+        field(:ch_time, Ch, type: "Time")
+        field(:ch_time64, Ch, type: "Time64(3)")
+        field(:time, :time)
+        field(:time_usec, :time_usec)
+      end
+    end
+
+    test "insert_all" do
+      assert {2, _} =
+               insert_all(Times, [
+                 Enum.map(Times.__schema__(:fields), fn field -> {field, nil} end),
+                 [
+                   ch_time: ~T[12:34:56],
+                   ch_time64: ~T[12:34:56.987654],
+                   time: ~T[12:34:56],
+                   time_usec: ~T[12:34:56.987654]
+                 ]
+               ])
+
+      assert Times |> order_by([t], t.ch_time) |> all() |> unstruct() == [
+               %{
+                 ch_time: ~T[00:00:00],
+                 ch_time64: ~T[00:00:00.000],
+                 time: ~T[00:00:00],
+                 time_usec: ~T[00:00:00.000000]
+               },
+               %{
+                 ch_time: ~T[12:34:56],
+                 ch_time64: ~T[12:34:56.987],
+                 time: ~T[12:34:56],
+                 time_usec: ~T[12:34:56.987654]
+               }
+             ]
+    end
+  end
+
+  @tag :time
+  test "Ecto query params round-trip at every supported precision" do
+    for time <- [
+          ~T[12:34:56],
+          ~T[12:34:56.1],
+          ~T[12:34:56.12],
+          ~T[12:34:56.123],
+          ~T[12:34:56.1234],
+          ~T[12:34:56.12345],
+          ~T[12:34:56.123456]
+        ] do
+      query = from _ in fragment("system.one"), select: fragment("?", ^time)
+      assert all(query) == [time]
+
+      sql = Ecto.Adapters.ClickHouse.to_inline_sql(:all, query)
+      assert query!(sql).rows == [[time]]
+    end
+  end
+
   describe "DateTime" do
     setup do
       query!("""

--- a/test/ecto/adapters/clickhouse/connection_test.exs
+++ b/test/ecto/adapters/clickhouse/connection_test.exs
@@ -1034,13 +1034,17 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
     assert all(query) == ~s[SELECT CAST(s0."x" + 1 AS UInt16) FROM "schema" AS s0]
   end
 
-  test "tagged unknown type" do
+  test "tagged time types" do
     query = from e in "events", select: type(e.count + 1, :time)
+    assert all(query) == ~s[SELECT CAST(e0."count" + CAST(1 AS Time) AS Time) FROM "events" AS e0]
 
-    assert_raise Ecto.QueryError,
-                 ~r/unknown or ambiguous \(for ClickHouse\) Ecto type :time in query/,
-                 fn -> all(query) end
+    query = from e in "events", select: type(e.count + 1, :time_usec)
 
+    assert all(query) ==
+             ~s[SELECT CAST(e0."count" + CAST(1 AS Time64(6)) AS Time64(6)) FROM "events" AS e0]
+  end
+
+  test "tagged unknown type" do
     query = from e in "events", select: type(e.count + 1, :decimal)
 
     assert_raise Ecto.QueryError,
@@ -2750,11 +2754,11 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
   test "create table with time columns" do
     create =
       {:create, table(:posts),
-       [{:add, :published_at, :time, []}, {:add, :submitted_at, :time, []}]}
+       [{:add, :published_at, :time, []}, {:add, :submitted_at, :time_usec, []}]}
 
-    assert_raise ArgumentError, "type :time is not supported", fn ->
-      execute_ddl(create)
-    end
+    assert execute_ddl(create) == [
+             ~s[CREATE TABLE "posts" ("published_at" Time,"submitted_at" Time64(6)) ENGINE=TinyLog]
+           ]
   end
 
   test "create table with utc_datetime columns" do
@@ -3566,6 +3570,24 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
            """
   end
 
+  test "Time and Time64 params" do
+    assert all(
+             from e in "events",
+               where: e.time == ^~T[12:34:56],
+               select: e.time
+           ) == """
+           SELECT e0."time" FROM "events" AS e0 WHERE (e0."time" = {$0:Time})\
+           """
+
+    assert all(
+             from e in "events",
+               where: e.time == ^~T[12:34:56.123456],
+               select: e.time
+           ) == """
+           SELECT e0."time" FROM "events" AS e0 WHERE (e0."time" = {$0:Time64(6)})\
+           """
+  end
+
   test "build_params/3" do
     params =
       [
@@ -3619,6 +3641,13 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
              )
            ) ==
              "1,'a',true,'2024-04-12'::date,'2024-04-12 09:55:54.329788'::DateTime64(6,'Etc/UTC'),'2024-04-12 09:55:54'::DateTime('Etc/UTC')"
+
+    assert to_string(
+             Connection.build_params(_ix = 0, _len = 2, [
+               Connection.mark_inline(~T[12:34:56]),
+               Connection.mark_inline(~T[12:34:56.123456])
+             ])
+           ) == "'12:34:56'::Time,'12:34:56.123456'::Time64(6)"
   end
 
   test "decimal parameter boundaries" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -41,7 +41,9 @@ env = [
 
 env =
   if ch_version >= "25" do
-    Keyword.update!(env, :settings, fn settings -> Keyword.put(settings, :enable_json_type, 1) end)
+    Keyword.update!(env, :settings, fn settings ->
+      Keyword.merge(settings, enable_json_type: 1, enable_time_time64_type: 1)
+    end)
   else
     env
   end


### PR DESCRIPTION
## Summary

- map Ecto `:time` to ClickHouse `Time`
- map Ecto `:time_usec` to `Time64(6)` in schemas, migrations, casts, and RowBinary inserts
- infer `Time` / `Time64(p)` for regular and inline query parameters

## Validation

- `mix test` (493 passed, 82 skipped, isolated database)
- `MIX_ENV=test mix compile --warnings-as-errors --force`
- `mix format --check-formatted`
- `mix dialyzer --format github`
- `mix deps.get --check-locked`
- `mix deps.unlock --check-unused`
- `typos`