### PR TITLE
Improved `IN` handling

### DIFF
--- a/lib/ecto/adapters/clickhouse.ex
+++ b/lib/ecto/adapters/clickhouse.ex
@@ -164,6 +164,7 @@ defmodule Ecto.Adapters.ClickHouse do
   def dumpers(:uuid, Ecto.UUID), do: [&__MODULE__.hex_uuid/1]
   def dumpers(:uuid, type), do: [type, &__MODULE__.hex_uuid/1]
   def dumpers(:binary_id, type), do: [type, &__MODULE__.hex_uuid/1]
+  def dumpers({:in, sub}, {:in, sub}), do: [{:array, sub}]
   def dumpers(_primitive, {:parameterized, {Ch, params}}), do: [dumper(params)]
   def dumpers({:parameterized, {Ch, params}}, type), do: [type, dumper(params)]
   def dumpers(_primitive, type), do: [type]

--- a/lib/ecto/adapters/clickhouse/connection.ex
+++ b/lib/ecto/adapters/clickhouse/connection.ex
@@ -677,14 +677,11 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
 
   defp expr({:in, _, [_, {:^, _, [_ix, 0]}]}, _sources, _params, _query), do: "0"
 
-  # Handle IN with pinned array parameter - use single array param instead of expanding
   defp expr({:in, _, [left, {:^, _, [ix, len]}]}, sources, params, query) when len > 0 do
-    # Collect all the individual params into a single array
-    array_values = Enum.map(ix..(ix + len - 1), &Enum.at(params, &1))
-    p = build_param(ix, array_values)
-    binding() |> dbg
+    array_values = Enum.at(params, ix)
+    param = build_param(ix, array_values)
 
-    [expr(left, sources, params, query), " IN ", p]
+    [expr(left, sources, params, query), " IN ", param]
   end
 
   defp expr({:in, _, [left, right]}, sources, params, query) do

--- a/lib/ecto/adapters/clickhouse/connection.ex
+++ b/lib/ecto/adapters/clickhouse/connection.ex
@@ -677,6 +677,16 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
 
   defp expr({:in, _, [_, {:^, _, [_ix, 0]}]}, _sources, _params, _query), do: "0"
 
+  # Handle IN with pinned array parameter - use single array param instead of expanding
+  defp expr({:in, _, [left, {:^, _, [ix, len]}]}, sources, params, query) when len > 0 do
+    # Collect all the individual params into a single array
+    array_values = Enum.map(ix..(ix + len - 1), &Enum.at(params, &1))
+    p = build_param(ix, array_values)
+    binding() |> dbg
+
+    [expr(left, sources, params, query), " IN ", p]
+  end
+
   defp expr({:in, _, [left, right]}, sources, params, query) do
     [expr(left, sources, params, query), " IN ", expr(right, sources, params, query)]
   end

--- a/lib/ecto/adapters/clickhouse/connection.ex
+++ b/lib/ecto/adapters/clickhouse/connection.ex
@@ -689,14 +689,11 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
 
   defp expr({:in, _, [_, {:^, _, [_ix, 0]}]}, _sources, _params, _query), do: "0"
 
-  # Handle IN with pinned array parameter - use single array param instead of expanding
   defp expr({:in, _, [left, {:^, _, [ix, len]}]}, sources, params, query) when len > 0 do
-    # Collect all the individual params into a single array
-    array_values = Enum.map(ix..(ix + len - 1), &Enum.at(params, &1))
-    p = build_param(ix, array_values)
-    binding() |> dbg
+    array_values = Enum.at(params, ix)
+    param = build_param(ix, array_values)
 
-    [expr(left, sources, params, query), " IN ", p]
+    [expr(left, sources, params, query), " IN ", param]
   end
 
   defp expr({:in, _, [left, right]}, sources, params, query) do

--- a/lib/ecto/adapters/clickhouse/connection.ex
+++ b/lib/ecto/adapters/clickhouse/connection.ex
@@ -689,6 +689,16 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
 
   defp expr({:in, _, [_, {:^, _, [_ix, 0]}]}, _sources, _params, _query), do: "0"
 
+  # Handle IN with pinned array parameter - use single array param instead of expanding
+  defp expr({:in, _, [left, {:^, _, [ix, len]}]}, sources, params, query) when len > 0 do
+    # Collect all the individual params into a single array
+    array_values = Enum.map(ix..(ix + len - 1), &Enum.at(params, &1))
+    p = build_param(ix, array_values)
+    binding() |> dbg
+
+    [expr(left, sources, params, query), " IN ", p]
+  end
+
   defp expr({:in, _, [left, right]}, sources, params, query) do
     [expr(left, sources, params, query), " IN ", expr(right, sources, params, query)]
   end

--- a/test/ecto/adapters/clickhouse/connection_test.exs
+++ b/test/ecto/adapters/clickhouse/connection_test.exs
@@ -1019,7 +1019,7 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
     assert all(query) == ~s[SELECT 0 FROM "schema" AS s0]
 
     query = Schema |> select([e], 1 in ^[1, 2, 3])
-    assert all(query) == ~s[SELECT 1 IN ({$0:Int64},{$1:Int64},{$2:Int64}) FROM "schema" AS s0]
+    assert all(query) == ~s[SELECT 1 IN {$0:Array(Int64)} FROM "schema" AS s0]
 
     query = Schema |> select([e], 1 in [1, ^2, 3])
     assert all(query) == ~s[SELECT 1 IN (1,{$0:Int64},3) FROM "schema" AS s0]
@@ -1027,7 +1027,7 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
     query = Schema |> select([e], e.x == ^0 or e.x in ^[1, 2, 3] or e.x == ^4)
 
     assert all(query) ==
-             ~s[SELECT (s0."x" = {$0:Int64}) OR (s0."x" IN ({$1:Int64},{$2:Int64},{$3:Int64})) OR (s0."x" = {$4:Int64}) FROM "schema" AS s0]
+             ~s[SELECT (s0."x" = {$0:Int64}) OR (s0."x" IN {$1:Array(Int64)}) OR (s0."x" = {$2:Int64}) FROM "schema" AS s0]
 
     query = Schema |> select([e], e in [1, 2, 3])
 

--- a/test/ecto/adapters/clickhouse/connection_test.exs
+++ b/test/ecto/adapters/clickhouse/connection_test.exs
@@ -1159,7 +1159,7 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
     assert all(query) == ~s[SELECT 0 FROM "schema" AS s0]
 
     query = Schema |> select([e], 1 in ^[1, 2, 3])
-    assert all(query) == ~s[SELECT 1 IN ({$0:Int64},{$1:Int64},{$2:Int64}) FROM "schema" AS s0]
+    assert all(query) == ~s[SELECT 1 IN {$0:Array(Int64)} FROM "schema" AS s0]
 
     query = Schema |> select([e], 1 in [1, ^2, 3])
     assert all(query) == ~s[SELECT 1 IN (1,{$0:Int64},3) FROM "schema" AS s0]
@@ -1167,7 +1167,7 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
     query = Schema |> select([e], e.x == ^0 or e.x in ^[1, 2, 3] or e.x == ^4)
 
     assert all(query) ==
-             ~s[SELECT (s0."x" = {$0:Int64}) OR (s0."x" IN ({$1:Int64},{$2:Int64},{$3:Int64})) OR (s0."x" = {$4:Int64}) FROM "schema" AS s0]
+             ~s[SELECT (s0."x" = {$0:Int64}) OR (s0."x" IN {$1:Array(Int64)}) OR (s0."x" = {$2:Int64}) FROM "schema" AS s0]
 
     query = Schema |> select([e], e in [1, 2, 3])
 

--- a/test/ecto/adapters/clickhouse/connection_test.exs
+++ b/test/ecto/adapters/clickhouse/connection_test.exs
@@ -3482,7 +3482,7 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
            ) ==
              """
              SELECT p0."id" FROM "posts" AS p0 \
-             WHERE (array(1,2,3) IN ({$0:Array(Nothing)}))\
+             WHERE (array(1,2,3) IN {$0:Array(Array(Nothing))})\
              """
 
     assert all(
@@ -3492,7 +3492,7 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
            ) ==
              """
              SELECT p0."id" FROM "posts" AS p0 \
-             WHERE (array(1,2,3) IN ({$0:Array(Nothing)},{$1:Array(Nothing)},{$2:Array(Int64)}))\
+             WHERE (array(1,2,3) IN {$0:Array(Array(Int64))})\
              """
 
     assert all(

--- a/test/ecto/integration/assoc_test.exs
+++ b/test/ecto/integration/assoc_test.exs
@@ -5,6 +5,7 @@ defmodule Ecto.Integration.AssocTest do
   alias Ecto.Integration.{Post, Comment, Permalink}
 
   test "has_many assoc" do
+    Logger.configure(level: :debug)
     p1 = TestRepo.insert!(%Post{title: "1"})
     p2 = TestRepo.insert!(%Post{title: "2"})
 
@@ -15,6 +16,8 @@ defmodule Ecto.Integration.AssocTest do
     [c1, c2] = TestRepo.all(Ecto.assoc(p1, :comments)) |> Enum.sort_by(& &1.id)
     assert c1.id == cid1
     assert c2.id == cid2
+
+    TestRepo.to_sql(:all, Ecto.assoc([p1, p2], :comments)) |> dbg
 
     [c1, c2, c3] = TestRepo.all(Ecto.assoc([p1, p2], :comments)) |> Enum.sort_by(& &1.id)
     assert c1.id == cid1

--- a/test/ecto/integration/assoc_test.exs
+++ b/test/ecto/integration/assoc_test.exs
@@ -5,7 +5,6 @@ defmodule Ecto.Integration.AssocTest do
   alias Ecto.Integration.{Post, Comment, Permalink}
 
   test "has_many assoc" do
-    Logger.configure(level: :debug)
     p1 = TestRepo.insert!(%Post{title: "1"})
     p2 = TestRepo.insert!(%Post{title: "2"})
 
@@ -16,8 +15,6 @@ defmodule Ecto.Integration.AssocTest do
     [c1, c2] = TestRepo.all(Ecto.assoc(p1, :comments)) |> Enum.sort_by(& &1.id)
     assert c1.id == cid1
     assert c2.id == cid2
-
-    TestRepo.to_sql(:all, Ecto.assoc([p1, p2], :comments)) |> dbg
 
     [c1, c2, c3] = TestRepo.all(Ecto.assoc([p1, p2], :comments)) |> Enum.sort_by(& &1.id)
     assert c1.id == cid1

--- a/test/ecto_ch_test.exs
+++ b/test/ecto_ch_test.exs
@@ -75,15 +75,14 @@ defmodule EctoCh.Test do
                  countIf(e0."type" != 'pageview') \
                  FROM "events" AS e0 \
                  WHERE (\
-                 e0."domain" IN ({$0:String},{$1:String})) AND \
-                 (e0."tags" = {$2:Array(String)}) AND \
-                 (toDate(e0."inserted_at") >= {$3:Date}) AND \
-                 (toDate(e0."inserted_at") <= {$4:Date}\
+                 e0."domain" IN {$0:Array(String)}) AND \
+                 (e0."tags" = {$1:Array(String)}) AND \
+                 (toDate(e0."inserted_at") >= {$2:Date}) AND \
+                 (toDate(e0."inserted_at") <= {$3:Date}\
                  )\
                  """,
                  [
-                   "dummy.site",
-                   "dummy2.site",
+                   ["dummy.site", "dummy2.site"],
                    ["1", "2", "3"],
                    ~D[2020-10-10],
                    ~D[2021-01-01]


### PR DESCRIPTION
# `IN` improvements for Ecto.CH

Hey folks, thanks for the library! We ran into a problem using the `in` operator over at CargoSense and we're hoping you're open to a change in the SQL those queries produce to make more efficient use of Clickhouse params.

## Problem
Currently when you have an ecto query like:

```
ids = [1,2,3]
from q in queryable, where: q.id in ^ids
```

This results in clickhouse SQL:

```
WHERE q.id in ($0:Int64,$1:Int64,$2:Int64)
```

This becomes an issue when `ids` or any other array parameter becomes very large, which is common when using Ecto CH to perform bulk operations in Clickhouse.

## Solution

Now in this PR the same Ecto query produces this Clickhouse SQL:

```
WHERE q.id in {$0:Array(Int64)}
```

We have just one parameter no matter the size of the array.