### PR TITLE
Support :comment column option in migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Support the `:comment` column option in migrations (`create`, `add`, and `modify`), which was previously silently ignored
+- Support the `:comment` column option in migrations (`create`, `add`, and `modify`), which was previously silently ignored https://github.com/plausible/ecto_ch/pull/282
 
 ## 0.9.3 (2026-05-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Support the `:comment` column option in migrations (`create`, `add`, and `modify`), which was previously silently ignored
+
 ## 0.9.3 (2026-05-07)
 
 - Use scientific Decimal rendering for inline literals and require Ch `~> 0.8.2` https://github.com/plausible/ecto_ch/pull/276

--- a/README.md
+++ b/README.md
@@ -122,6 +122,22 @@ CREATE TABLE `posts` ON CLUSTER `my-cluster` (
 ) ENGINE ReplicatedMergeTree ORDER BY tuple()
 ```
 
+Column options like `:default`, `:null`, and `:comment` are supported as well, and work in `create`, `add`, and `modify`:
+
+```elixir
+create table(:posts, primary_key: false, engine: "MergeTree", options: [order_by: "tuple()"]) do
+  add :user_id, :UInt64, comment: "ClickPipes source"
+end
+```
+
+is equivalent to
+
+```sql
+CREATE TABLE `posts` (
+  `user_id` UInt64 COMMENT 'ClickPipes source'
+) ENGINE MergeTree ORDER BY tuple()
+```
+
 ## Caveats
 
 #### [ALTER TABLE ... UPDATE](https://clickhouse.com/docs/en/sql-reference/statements/alter/update)

--- a/lib/ecto/adapters/clickhouse/migration.ex
+++ b/lib/ecto/adapters/clickhouse/migration.ex
@@ -316,7 +316,8 @@ defmodule Ecto.Adapters.ClickHouse.Migration do
   defp column_options(type, opts) do
     default = Keyword.fetch(opts, :default)
     null = Keyword.get(opts, :null)
-    [default_expr(default, type), null_expr(null)]
+    comment = Keyword.get(opts, :comment)
+    [default_expr(default, type), null_expr(null), comment_expr(comment)]
   end
 
   defp column_change({:add, _name, %Reference{}, _opts}) do
@@ -343,8 +344,9 @@ defmodule Ecto.Adapters.ClickHouse.Migration do
       @conn.quote_name(name),
       ?\s,
       column_type(type),
-      modify_default(name, type, opts)
-      | modify_null(name, opts)
+      modify_default(name, type, opts),
+      modify_null(name, opts),
+      comment_expr(Keyword.get(opts, :comment))
     ]
   end
 
@@ -377,6 +379,9 @@ defmodule Ecto.Adapters.ClickHouse.Migration do
   defp null_expr(true), do: " NULL"
   defp null_expr(false), do: " NOT NULL"
   defp null_expr(_), do: []
+
+  defp comment_expr(nil), do: []
+  defp comment_expr(comment), do: [" COMMENT '", @conn.escape_string(comment), ?']
 
   @dialyzer {:no_improper_lists, default_expr: 2}
   defp default_expr({:ok, nil}, _type) do

--- a/test/ecto/adapters/clickhouse/connection_test.exs
+++ b/test/ecto/adapters/clickhouse/connection_test.exs
@@ -2891,6 +2891,66 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
            ]
   end
 
+  test "create table with column comment" do
+    create =
+      {:create, table(:posts, engine: "MergeTree"),
+       [
+         {:add, :user_id, :UInt64, [comment: "ClickPipes source"]}
+       ]}
+
+    assert execute_ddl(create) == [
+             ~s{CREATE TABLE "posts" ("user_id" UInt64 COMMENT 'ClickPipes source') ENGINE=MergeTree}
+           ]
+  end
+
+  test "create table with column comment combined with default and null" do
+    create =
+      {:create, table(:posts, engine: "MergeTree"),
+       [
+         {:add, :name, :string, [default: "Untitled", null: false, comment: "the name"]}
+       ]}
+
+    assert execute_ddl(create) == [
+             ~s{CREATE TABLE "posts" ("name" String DEFAULT 'Untitled' NOT NULL COMMENT 'the name') ENGINE=MergeTree}
+           ]
+  end
+
+  test "alter table adds column with comment" do
+    alter =
+      {:alter, table(:posts),
+       [
+         {:add, :_key, :string, [comment: "Kinesis partition key"]}
+       ]}
+
+    assert execute_ddl(alter) == [
+             ~s{ALTER TABLE "posts" ADD COLUMN "_key" String COMMENT 'Kinesis partition key'}
+           ]
+  end
+
+  test "alter table modifies column with comment" do
+    alter =
+      {:alter, table(:posts),
+       [
+         {:modify, :_key, :string, [comment: "Kinesis partition key"]}
+       ]}
+
+    assert execute_ddl(alter) == [
+             ~s{ALTER TABLE "posts" MODIFY COLUMN "_key" String COMMENT 'Kinesis partition key'}
+           ]
+  end
+
+  test "column comment escapes single quotes" do
+    create =
+      {:create, table(:posts, engine: "MergeTree"),
+       [
+         {:add, :user_id, :UInt64, [comment: "user's id"]}
+       ]}
+
+    assert execute_ddl(create) == [
+             ~s{CREATE TABLE "posts" ("user_id" UInt64 COMMENT 'user''s id') ENGINE=MergeTree}
+           ]
+  end
+
   test "create index" do
     create =
       {:create,


### PR DESCRIPTION
The Ecto migration DSL allows a `:comment` option. ClickHouse fully supports column comments, but the adapter previously honored only the table-level comment and the `:default`/`:null` column options, silently dropping `:comment`.

This wires a `comment_expr/1` helper into `column_options/2` (used by CREATE TABLE and ADD COLUMN) and into the `:modify` clause of `column_change/2` (MODIFY COLUMN). The comment is emitted as an inline `COMMENT '...'` suffix after the type and any DEFAULT/NULL expressions, matching ClickHouse syntax.

Single quotes in the comment are escaped via `Connection.escape_string/1` (the same helper used for string DEFAULT literals), producing valid SQL. Output is unchanged when `:comment` is absent.

cc @ruslandoga 