### PR TITLE
Adapt array type test for ClickHouse 26.7

### DIFF
--- a/test/ecto/integration/type_test.exs
+++ b/test/ecto/integration/type_test.exs
@@ -296,31 +296,38 @@ defmodule Ecto.Integration.TypeTest do
     assert TestRepo.all(from t in Tag, where: t.ints == [1, 2, 3], select: t.ints) == [ints]
     assert TestRepo.all(from t in "tags", where: t.ints == [1, 2, 3], select: t.ints) == [ints]
 
-    # ClickHouse doesn't support IN operator on array columns
-    # works: select 1 in [1,2,3]
-    # fails: select * from tags t where 0 in t.ints
+    if clickhouse_version() >= [26, 7] do
+      assert TestRepo.all(from t in Tag, where: 0 in t.ints, select: t.ints) == []
+      assert TestRepo.all(from t in Tag, where: 1 in t.ints, select: t.ints) == [ints]
+      assert TestRepo.all(from t in Tag, where: ^0 in t.ints, select: t.ints) == []
+      assert TestRepo.all(from t in Tag, where: ^1 in t.ints, select: t.ints) == [ints]
+    else
+      # ClickHouse before 26.7 doesn't support IN operator on array columns
+      # works: select 1 in [1,2,3]
+      # fails: select * from tags t where 0 in t.ints
 
-    expected_error_message =
-      cond do
-        clickhouse_version() > [26] -> ~r/ILLEGAL_TYPE_OF_ARGUMENT/
-        clickhouse_version() > [24] -> ~r/UNSUPPORTED_METHOD/
-        true -> ~r/UNKNOWN_TABLE/
+      expected_error_message =
+        cond do
+          clickhouse_version() > [26] -> ~r/ILLEGAL_TYPE_OF_ARGUMENT/
+          clickhouse_version() > [24] -> ~r/UNSUPPORTED_METHOD/
+          true -> ~r/UNKNOWN_TABLE/
+        end
+
+      assert_raise Ch.Error, expected_error_message, fn ->
+        TestRepo.all(from t in Tag, where: 0 in t.ints, select: t.ints)
       end
 
-    assert_raise Ch.Error, expected_error_message, fn ->
-      TestRepo.all(from t in Tag, where: 0 in t.ints, select: t.ints)
-    end
+      assert_raise Ch.Error, expected_error_message, fn ->
+        TestRepo.all(from t in Tag, where: 1 in t.ints, select: t.ints)
+      end
 
-    assert_raise Ch.Error, expected_error_message, fn ->
-      TestRepo.all(from t in Tag, where: 1 in t.ints, select: t.ints)
-    end
+      assert_raise Ch.Error, expected_error_message, fn ->
+        TestRepo.all(from t in Tag, where: ^0 in t.ints, select: t.ints)
+      end
 
-    assert_raise Ch.Error, expected_error_message, fn ->
-      TestRepo.all(from t in Tag, where: ^0 in t.ints, select: t.ints)
-    end
-
-    assert_raise Ch.Error, expected_error_message, fn ->
-      TestRepo.all(from t in Tag, where: ^1 in t.ints, select: t.ints)
+      assert_raise Ch.Error, expected_error_message, fn ->
+        TestRepo.all(from t in Tag, where: ^1 in t.ints, select: t.ints)
+      end
     end
 
     # has(arr, el) can be used instead


### PR DESCRIPTION
ClickHouse 26.7 added support for using `IN` with array columns, so the integration test's unconditional error expectation began failing on the `latest` image.
This updates the test to assert membership results on ClickHouse 26.7 and newer while preserving the existing error assertions for older versions.
Both literal and interpolated values are covered.
Validated against ClickHouse 26.6.1 and 26.7.1, with the full suite passing: 484 tests and 2 doctests.
