### PR TITLE
Fix defaults when modifying ClickHouse columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Require a table name when running `ecto.ch.schema` with repo options https://github.com/plausible/ecto_ch/pull/291
+- Fix invalid `MODIFY COLUMN` SQL when setting a column default https://github.com/plausible/ecto_ch/pull/290
 
 ## 0.10.0 (2026-06-02)
 

--- a/lib/ecto/adapters/clickhouse/migration.ex
+++ b/lib/ecto/adapters/clickhouse/migration.ex
@@ -344,7 +344,7 @@ defmodule Ecto.Adapters.ClickHouse.Migration do
       @conn.quote_name(name),
       ?\s,
       column_type(type),
-      modify_default(name, type, opts),
+      modify_default(type, opts),
       modify_null(name, opts),
       comment_expr(Keyword.get(opts, :comment))
     ]
@@ -366,10 +366,10 @@ defmodule Ecto.Adapters.ClickHouse.Migration do
     end
   end
 
-  defp modify_default(name, type, opts) do
+  defp modify_default(type, opts) do
     case Keyword.fetch(opts, :default) do
       {:ok, _val} = ok ->
-        [" ADD ", default_expr(ok, type), " FOR ", @conn.quote_name(name)]
+        default_expr(ok, type)
 
       :error ->
         []

--- a/test/ecto/adapters/clickhouse/connection_test.exs
+++ b/test/ecto/adapters/clickhouse/connection_test.exs
@@ -2867,6 +2867,18 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
            ]
   end
 
+  test "alter column modifies default" do
+    alter =
+      {:alter, table(:posts),
+       [
+         {:modify, :price, :UInt64, [default: 1]}
+       ]}
+
+    assert execute_ddl(alter) == [
+             ~s{ALTER TABLE "posts" MODIFY COLUMN "price" UInt64 DEFAULT 1}
+           ]
+  end
+
   test "alter table removes column" do
     alteration = {
       :alter,

--- a/test/ecto/adapters/clickhouse/migration_test.exs
+++ b/test/ecto/adapters/clickhouse/migration_test.exs
@@ -53,6 +53,27 @@ defmodule Ecto.Adapters.ClickHouse.MigrationTest do
     end
   end
 
+  defmodule CreateProducts do
+    use Ecto.Migration
+
+    def change do
+      create table(:products, primary_key: false, engine: "Memory") do
+        add :name, :string
+        add :price, :UInt64
+      end
+    end
+  end
+
+  defmodule AddPriceDefault do
+    use Ecto.Migration
+
+    def change do
+      alter table(:products) do
+        modify :price, :UInt64, default: 1
+      end
+    end
+  end
+
   test "events (table+index)" do
     database = "ecto_ch_migration_test_events"
     opts = [database: database]
@@ -143,5 +164,35 @@ defmodule Ecto.Adapters.ClickHouse.MigrationTest do
                """
              ]
            ]
+  end
+
+  test "modify column default" do
+    database = "ecto_ch_migration_test_modify_default"
+    opts = [database: database]
+
+    assert :ok = ClickHouse.storage_up(opts)
+    on_exit(fn -> ClickHouse.storage_down(opts) end)
+
+    Application.put_env(:migration_test, MigrationRepo,
+      database: database,
+      show_sensitive_data_on_connection_error: true
+    )
+
+    on_exit(fn -> Application.delete_env(:migration_test, MigrationRepo) end)
+
+    start_supervised!(MigrationRepo)
+
+    assert [1, 2] ==
+             Ecto.Migrator.run(MigrationRepo, [{1, CreateProducts}, {2, AddPriceDefault}], :up,
+               all: true,
+               log: false
+             )
+
+    conn = start_supervised!({Ch, opts})
+
+    assert %{num_rows: 1} =
+             Ch.query!(conn, "INSERT INTO products (name) VALUES ('book')")
+
+    assert [[1]] == Ch.query!(conn, "SELECT price FROM products").rows
   end
 end


### PR DESCRIPTION
Fixes MODIFY COLUMN migrations with defaults to emit ClickHouse's valid DEFAULT syntax instead of ADD DEFAULT ... FOR.

Adds a SQL rendering regression test and an end-to-end migration test that runs against ClickHouse, inserts a row without the modified column, and verifies the default is applied.

Tested against ClickHouse 26.7.1.1315.