### PR TITLE
Document and test schema task table requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.10.0 (2026-06-02)
 
+- Require a table name when running `ecto.ch.schema` with repo options https://github.com/plausible/ecto_ch/pull/291
 - Breaking change: compile `json_extract_path/2` and Ecto JSON access syntax to native ClickHouse JSON paths like `json.foo.bar` instead of `JSON_QUERY(json, '$.foo.bar')`. https://github.com/plausible/ecto_ch/pull/284
 
 ## 0.9.4 (2026-05-30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
-## 0.10.0 (2026-06-02)
+## Unreleased
 
 - Require a table name when running `ecto.ch.schema` with repo options https://github.com/plausible/ecto_ch/pull/291
+
+## 0.10.0 (2026-06-02)
+
 - Breaking change: compile `json_extract_path/2` and Ecto JSON access syntax to native ClickHouse JSON paths like `json.foo.bar` instead of `JSON_QUERY(json, '$.foo.bar')`. https://github.com/plausible/ecto_ch/pull/284
 
 ## 0.9.4 (2026-05-30)

--- a/test/mix/tasks/schema_test.exs
+++ b/test/mix/tasks/schema_test.exs
@@ -183,6 +183,14 @@ defmodule Mix.Tasks.Ecto.Ch.SchemaTest do
   end
 
   describe "run/1 custom repo flags" do
+    test "requires a table name" do
+      assert_raise ArgumentError,
+                   ~s(missing table name, got only options: ["--repo", "SomeRepo"]),
+                   fn ->
+                     Mix.Tasks.Ecto.Ch.Schema.run(["--repo", "SomeRepo"])
+                   end
+    end
+
     test "-r" do
       schema =
         capture_io(fn ->


### PR DESCRIPTION
Adds regression coverage for invoking `ecto.ch.schema` with `--repo` but no table name. The test verifies the task raises the explicit missing-table `ArgumentError` instead of reaching `String.split/2` with `nil`. The table-name requirement is also recorded in the changelog.

Tested with `mix test test/mix/tasks/schema_test.exs:186`.