### PR TITLE
Remove stray debug output from input-query inserts

### DIFF
--- a/lib/ecto/adapters/clickhouse/schema.ex
+++ b/lib/ecto/adapters/clickhouse/schema.ex
@@ -106,7 +106,7 @@ defmodule Ecto.Adapters.ClickHouse.Schema do
         %Ecto.Query.SelectExpr{expr: {:merge, _, [{:&, _, [_]}, {:%{}, _, args}]}} ->
           fields = Keyword.keys(types)
           merged = Enum.map(args, &elem(&1, 0))
-          Enum.uniq(fields ++ merged) |> IO.inspect()
+          Enum.uniq(fields ++ merged)
 
         _ ->
           raise ArgumentError, """

--- a/test/ecto/integration/aggregate_function_type_test.exs
+++ b/test/ecto/integration/aggregate_function_type_test.exs
@@ -139,9 +139,6 @@ defmodule Ecto.Integration.AggregateFunctionTypeTest do
         [uid: 1231, updated: ~N[2020-01-01 00:00:00], name: "John"]
       ]
 
-      # Rexbug.start("Ch :: return", msgs: 10000)
-      # on_exit(fn -> :timer.sleep(100) end)
-
       assert {2, _} = TestRepo.insert_all(UserInput, rows, input: input)
 
       assert "agg_test_users"

--- a/test/ecto_ch_test.exs
+++ b/test/ecto_ch_test.exs
@@ -121,10 +121,6 @@ defmodule EctoCh.Test do
     {IO.iodata_to_binary(f.(query, dump_params)), dump_params}
   end
 
-  def i(query) do
-    IO.inspect(Map.from_struct(query), limit: :infinity)
-  end
-
   test "to_sql" do
     user_id = 1
     query = "example" |> where([e], e.user_id == ^user_id) |> select([e], e.name)


### PR DESCRIPTION
Removes an accidental `IO.inspect/1` from the input-query `select_merge` header path so `insert_all/3` no longer writes generated headers to stdout. Also removes an unused test inspection helper and stale commented Rexbug setup.

Verification: `mix format --check-formatted` and `mix test test/ecto/integration/aggregate_function_type_test.exs` (6 tests passed).