### PR TITLE
Fix dumps with empty schema migration history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Require a table name when running `ecto.ch.schema` with repo options https://github.com/plausible/ecto_ch/pull/291
 - Fix invalid `MODIFY COLUMN` SQL when setting a column default https://github.com/plausible/ecto_ch/pull/290
+- Fix invalid structure dumps when the schema migration history is empty https://github.com/plausible/ecto_ch/pull/294
 
 ## 0.10.0 (2026-06-02)
 

--- a/lib/ecto/adapters/clickhouse/structure.ex
+++ b/lib/ecto/adapters/clickhouse/structure.ex
@@ -76,8 +76,16 @@ defmodule Ecto.Adapters.ClickHouse.Structure do
     stmt = "SELECT * FROM #{table} FORMAT Values"
 
     with {:ok, %{rows: rows}, conn} <- exec(conn, stmt) do
-      rows = rows |> IO.iodata_to_binary() |> String.replace("),(", "),\n(")
-      versions = ["INSERT INTO ", table, " (version, inserted_at) VALUES\n", rows, ";\n"]
+      versions =
+        case IO.iodata_to_binary(rows) do
+          "" ->
+            []
+
+          rows ->
+            rows = String.replace(rows, "),(", "),\n(")
+            ["INSERT INTO ", table, " (version, inserted_at) VALUES\n", rows, ";\n"]
+        end
+
       {:ok, versions, conn}
     end
   end

--- a/test/ecto/adapters/clickhouse/structure_test.exs
+++ b/test/ecto/adapters/clickhouse/structure_test.exs
@@ -233,6 +233,39 @@ defmodule Ecto.Adapters.ClickHouse.StructureTest do
                (2,'#{inserted_at_2}');
                """
     end
+
+    test "dumps and loads an empty migration history" do
+      database = "ecto_ch_temp_structure_no_migrations"
+      opts = [database: database]
+
+      assert :ok = ClickHouse.storage_up(opts)
+      on_exit(fn -> ClickHouse.storage_down(opts) end)
+
+      Application.put_env(:structure_test, Repo,
+        database: database,
+        show_sensitive_data_on_connection_error: true
+      )
+
+      on_exit(fn -> Application.delete_env(:structure_test, Repo) end)
+
+      start_supervised!(Repo)
+
+      assert [] == Ecto.Migrator.run(Repo, [], :up, all: true, log: false)
+
+      tmp = System.tmp_dir!()
+
+      assert {:ok, path} = ClickHouse.structure_dump(tmp, opts)
+      on_exit(fn -> File.rm!(path) end)
+
+      structure = File.read!(path)
+
+      refute structure =~ "INSERT INTO"
+
+      Repo.query!("DROP TABLE schema_migrations")
+
+      assert {:ok, ^path} = ClickHouse.structure_load(tmp, opts)
+      assert Repo.query!("SELECT * FROM schema_migrations").rows == []
+    end
   end
 
   describe "structure_load/2" do


### PR DESCRIPTION
## Summary

- omit the schema migrations `INSERT` when `FORMAT Values` returns no rows
- add regression coverage proving an empty migration-history dump can be loaded

## Tests

- `mix test test/ecto/adapters/clickhouse/structure_test.exs`