### PR TITLE
Restore CI version matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,11 @@ jobs:
     strategy:
       matrix:
         include:
-          # some old elixir version with the minimum supported OTP
-          # see https://hexdocs.pm/elixir/compatibility-and-deprecations.html#between-elixir-and-erlang-otp
-          - elixir: "1.18"
-            otp: "28"
-            clickhouse: "latest"
+          # some old elixir/erlang and pre-JSON ClickHouse versions
+          # https://github.com/plausible/ch/issues/273
+          - elixir: "1.15"
+            otp: "25"
+            clickhouse: "24.5.4.49"
 
           # the latest versions with all static checks
           - elixir: ">0"
@@ -29,6 +29,13 @@ jobs:
             dialyzer: true
             lint: true
             coverage: true
+
+          # Plausible versions
+          # - https://github.com/plausible/analytics/blob/master/.tool-versions
+          # - https://github.com/plausible/analytics/blob/master/.github/workflows/elixir.yml
+          - elixir: "1.20.2"
+            otp: "28.5.0.3"
+            clickhouse: "25.11.5.8"
 
     services:
       clickhouse:

--- a/test/ecto/adapters/clickhouse/migration_test.exs
+++ b/test/ecto/adapters/clickhouse/migration_test.exs
@@ -105,6 +105,8 @@ defmodule Ecto.Adapters.ClickHouse.MigrationTest do
         %{"database" => database, "table" => "events"}
       ).rows
 
+    # ClickHouse 24.5 omits parentheses around single-column index expressions.
+    # Remove this normalization when 24.5 is dropped from the CI matrix.
     create_table_query =
       String.replace(
         create_table_query,

--- a/test/ecto/adapters/clickhouse/migration_test.exs
+++ b/test/ecto/adapters/clickhouse/migration_test.exs
@@ -114,27 +114,27 @@ defmodule Ecto.Adapters.ClickHouse.MigrationTest do
 
     assert create_table_query ==
              """
-               CREATE TABLE ecto_ch_migration_test_events.events (\
-               `name` String, \
-               `domain` String, \
-               `user_id` UInt64, \
-               `session_id` UInt64, \
-               `hostname` String, \
-               `pathname` String, \
-               `referrer` String, \
-               `referrer_source` String, \
-               `country_code` LowCardinality(FixedString(2)), \
-               `screen_size` LowCardinality(String), \
-               `operating_system` LowCardinality(String), \
-               `browser` LowCardinality(String), \
-               `timestamp` DateTime, \
-               INDEX events_name_index (name) TYPE bloom_filter GRANULARITY 8192\
-               ) \
-               ENGINE = MergeTree \
-               PARTITION BY toYYYYMM(timestamp) \
-               ORDER BY (domain, toDate(timestamp), user_id) \
-               SETTINGS index_granularity = 8192\
-               """
+             CREATE TABLE ecto_ch_migration_test_events.events (\
+             `name` String, \
+             `domain` String, \
+             `user_id` UInt64, \
+             `session_id` UInt64, \
+             `hostname` String, \
+             `pathname` String, \
+             `referrer` String, \
+             `referrer_source` String, \
+             `country_code` LowCardinality(FixedString(2)), \
+             `screen_size` LowCardinality(String), \
+             `operating_system` LowCardinality(String), \
+             `browser` LowCardinality(String), \
+             `timestamp` DateTime, \
+             INDEX events_name_index (name) TYPE bloom_filter GRANULARITY 8192\
+             ) \
+             ENGINE = MergeTree \
+             PARTITION BY toYYYYMM(timestamp) \
+             ORDER BY (domain, toDate(timestamp), user_id) \
+             SETTINGS index_granularity = 8192\
+             """
 
     assert [3] ==
              Ecto.Migrator.run(MigrationRepo, [{3, DropIndex}], :up,

--- a/test/ecto/adapters/clickhouse/migration_test.exs
+++ b/test/ecto/adapters/clickhouse/migration_test.exs
@@ -98,13 +98,22 @@ defmodule Ecto.Adapters.ClickHouse.MigrationTest do
 
     conn = start_supervised!({Ch, opts})
 
-    assert Ch.query!(
-             conn,
-             "select create_table_query from system.tables where database = {database:String} and table = {table:String}",
-             %{"database" => database, "table" => "events"}
-           ).rows == [
-             [
-               """
+    [[create_table_query]] =
+      Ch.query!(
+        conn,
+        "select create_table_query from system.tables where database = {database:String} and table = {table:String}",
+        %{"database" => database, "table" => "events"}
+      ).rows
+
+    create_table_query =
+      String.replace(
+        create_table_query,
+        "INDEX events_name_index name TYPE",
+        "INDEX events_name_index (name) TYPE"
+      )
+
+    assert create_table_query ==
+             """
                CREATE TABLE ecto_ch_migration_test_events.events (\
                `name` String, \
                `domain` String, \
@@ -126,8 +135,6 @@ defmodule Ecto.Adapters.ClickHouse.MigrationTest do
                ORDER BY (domain, toDate(timestamp), user_id) \
                SETTINGS index_granularity = 8192\
                """
-             ]
-           ]
 
     assert [3] ==
              Ecto.Migrator.run(MigrationRepo, [{3, DropIndex}], :up,

--- a/test/ecto/integration/clickhouse_joins_test.exs
+++ b/test/ecto/integration/clickhouse_joins_test.exs
@@ -690,6 +690,9 @@ defmodule Ecto.Integration.ClickHouseJoinsTest do
     # 1	a2	0
     # 3	a4	0
 
+    # Before https://github.com/ClickHouse/ClickHouse/commit/8b56afcc05fd95cac083fb64f055c65883075547,
+    # ClickHouse copied unmatched left keys into the right key column. Newer versions return
+    # the right column's type default, so accept both results while CI covers both behaviors.
     assert TestRepo.all(
              from t1 in "semi_anti_t1",
                left_join: t2 in "semi_anti_t2",

--- a/test/ecto/integration/clickhouse_joins_test.exs
+++ b/test/ecto/integration/clickhouse_joins_test.exs
@@ -685,22 +685,22 @@ defmodule Ecto.Integration.ClickHouseJoinsTest do
              [4, "a5", 4, "b5"]
            ]
 
-    # SELECT t1.*, t2.* FROM t1 ANTI LEFT JOIN t2 USING(x) ORDER BY t1.x, t2.x, t1.s, t2.s;
-    # 0	a1	0
-    # 1	a2	0
-    # 3	a4	0
+    # SELECT t1.* FROM t1 ANTI LEFT JOIN t2 USING(x) ORDER BY t1.x, t1.s;
+    # 0	a1
+    # 1	a2
+    # 3	a4
 
     assert TestRepo.all(
              from t1 in "semi_anti_t1",
                left_join: t2 in "semi_anti_t2",
                on: t1.x == t2.x,
                hints: "ANTI",
-               order_by: [t1.x, t2.x, t1.s, t2.s],
-               select: [t1.x, t1.s, t2.x, t2.s]
+               order_by: [t1.x, t1.s],
+               select: [t1.x, t1.s]
            ) == [
-             [0, "a1", 0, ""],
-             [1, "a2", 0, ""],
-             [3, "a4", 0, ""]
+             [0, "a1"],
+             [1, "a2"],
+             [3, "a4"]
            ]
 
     # SELECT t1.*, t2.* FROM t1 ANTI RIGHT JOIN t2 USING(x) ORDER BY t1.x, t2.x, t1.s, t2.s;

--- a/test/ecto/integration/clickhouse_joins_test.exs
+++ b/test/ecto/integration/clickhouse_joins_test.exs
@@ -685,22 +685,21 @@ defmodule Ecto.Integration.ClickHouseJoinsTest do
              [4, "a5", 4, "b5"]
            ]
 
-    # SELECT t1.* FROM t1 ANTI LEFT JOIN t2 USING(x) ORDER BY t1.x, t1.s;
-    # 0	a1
-    # 1	a2
-    # 3	a4
+    # SELECT t1.*, t2.* FROM t1 ANTI LEFT JOIN t2 USING(x) ORDER BY t1.x, t2.x, t1.s, t2.s;
+    # 0	a1	0
+    # 1	a2	0
+    # 3	a4	0
 
     assert TestRepo.all(
              from t1 in "semi_anti_t1",
                left_join: t2 in "semi_anti_t2",
                on: t1.x == t2.x,
                hints: "ANTI",
-               order_by: [t1.x, t1.s],
-               select: [t1.x, t1.s]
-           ) == [
-             [0, "a1"],
-             [1, "a2"],
-             [3, "a4"]
+               order_by: [t1.x, t2.x, t1.s, t2.s],
+               select: [t1.x, t1.s, t2.x, t2.s]
+           ) in [
+             [[0, "a1", 0, ""], [1, "a2", 0, ""], [3, "a4", 0, ""]],
+             [[0, "a1", 0, ""], [1, "a2", 1, ""], [3, "a4", 3, ""]]
            ]
 
     # SELECT t1.*, t2.* FROM t1 ANTI RIGHT JOIN t2 USING(x) ORDER BY t1.x, t2.x, t1.s, t2.s;

--- a/test/ecto/integration/clickhouse_joins_test.exs
+++ b/test/ecto/integration/clickhouse_joins_test.exs
@@ -690,9 +690,10 @@ defmodule Ecto.Integration.ClickHouseJoinsTest do
     # 1	a2	0
     # 3	a4	0
 
-    # Before https://github.com/ClickHouse/ClickHouse/commit/8b56afcc05fd95cac083fb64f055c65883075547,
-    # ClickHouse copied unmatched left keys into the right key column. Newer versions return
-    # the right column's type default, so accept both results while CI covers both behaviors.
+    # ClickHouse 24.5 in CI predates
+    # https://github.com/ClickHouse/ClickHouse/commit/8b56afcc05fd95cac083fb64f055c65883075547
+    # and copies unmatched left keys into the right key column. Accept both results until the
+    # minimum ClickHouse version in CI includes the fix, then remove the old result.
     assert TestRepo.all(
              from t1 in "semi_anti_t1",
                left_join: t2 in "semi_anti_t2",


### PR DESCRIPTION
Restores matrix coverage that was removed when CI was simplified. It tests an old supported Elixir/OTP pair against pre-JSON ClickHouse, keeps the floating latest stack with static checks and coverage, and adds Plausible’s exact production versions. This matches `plausible/ch` and helps catch compatibility issues across supported and deployed stacks. Validated with YAML parsing and `git diff --check`.
