### PR TITLE
Fix ClickHouse CI health check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,12 +43,12 @@ jobs:
           - 8123:8123
         env:
           # https://github.com/ClickHouse/ClickHouse/issues/75494
-          CLICKHOUSE_SKIP_USER_SETUP: 1
-          options: >-
-            --health-cmd nc -zw3 localhost 8124
-            --health-interval 10s
-            --health-timeout 5s
-            --health-retries 5
+          CLICKHOUSE_SKIP_USER_SETUP: "1"
+        options: >-
+          --health-cmd "wget --no-verbose --tries=1 --spider http://127.0.0.1:8123/ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     env:
       MIX_ENV: test


### PR DESCRIPTION
Fix the ClickHouse GitHub Actions service health check by moving Docker options out of `env` and probing `/ping` with `wget` on the exposed port `8123`.

The previous options block was treated as an environment variable; even if correctly nested, its `nc` command was unavailable in the pinned ClickHouse image and targeted the wrong port.

This makes CI wait for ClickHouse's HTTP interface to become responsive across the version matrix.

Validation: `git diff --check` and a parsed-workflow assertion covering the service options and environment.
