### PR TITLE
Raise on combinations with limit or offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Raise when combination queries have a parent `LIMIT` or `OFFSET` and direct callers to wrap the combination in `subquery/1` https://github.com/plausible/ecto_ch/pull/301
+
 ## 0.11.0 (2026-08-08)
 
 - Support Ecto 3.14 and require Ch `~> 0.9.0` https://github.com/plausible/ecto_ch/pull/286 https://github.com/plausible/ecto_ch/pull/295

--- a/lib/ecto/adapters/clickhouse/connection.ex
+++ b/lib/ecto/adapters/clickhouse/connection.ex
@@ -555,6 +555,18 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
     [" OFFSET ", expr(expr, sources, params, query)]
   end
 
+  defp combinations(
+         %{combinations: [_ | _], limit: limit, offset: offset} = query,
+         _params
+       )
+       when not is_nil(limit) or not is_nil(offset) do
+    raise Ecto.QueryError,
+      query: query,
+      message:
+        "ClickHouse applies LIMIT and OFFSET to individual SELECT queries, " <>
+          "not the combination result -- wrap the combination in subquery/1 before applying them"
+  end
+
   defp combinations(%{combinations: combinations}, params) do
     Enum.map(combinations, &combination(&1, params))
   end

--- a/test/ecto/adapters/clickhouse/connection_test.exs
+++ b/test/ecto/adapters/clickhouse/connection_test.exs
@@ -611,8 +611,6 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
       Schema
       |> select([r], r.x)
       |> order_by(fragment("rand()"))
-      |> offset(10)
-      |> limit(5)
 
     union_query1 =
       Schema
@@ -635,7 +633,7 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
 
     assert all(query) ==
              """
-             SELECT s0."x" FROM "schema" AS s0 ORDER BY rand() LIMIT 5 OFFSET 10 \
+             SELECT s0."x" FROM "schema" AS s0 ORDER BY rand() \
              UNION DISTINCT (SELECT s0."y" FROM "schema" AS s0 ORDER BY s0."y" LIMIT 40 OFFSET 20) \
              UNION DISTINCT (SELECT s0."z" FROM "schema" AS s0 ORDER BY s0."z" LIMIT 60 OFFSET 30)\
              """
@@ -647,10 +645,46 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
 
     assert all(query) ==
              """
-             SELECT s0."x" FROM "schema" AS s0 ORDER BY rand() LIMIT 5 OFFSET 10 \
+             SELECT s0."x" FROM "schema" AS s0 ORDER BY rand() \
              UNION ALL (SELECT s0."y" FROM "schema" AS s0 ORDER BY s0."y" LIMIT 40 OFFSET 20) \
              UNION ALL (SELECT s0."z" FROM "schema" AS s0 ORDER BY s0."z" LIMIT 60 OFFSET 30)\
              """
+  end
+
+  test "limit and offset on combination queries" do
+    other_query = Schema |> select([r], r.y)
+    base_query = Schema |> select([r], r.x)
+
+    combination_queries = [
+      union(base_query, ^other_query),
+      union_all(base_query, ^other_query),
+      except(base_query, ^other_query),
+      intersect(base_query, ^other_query)
+    ]
+
+    error_message =
+      ~r/ClickHouse applies LIMIT and OFFSET.*combination result.*subquery\/1/
+
+    for combination_query <- combination_queries do
+      assert_raise Ecto.QueryError, error_message, fn ->
+        combination_query |> limit(5) |> all()
+      end
+
+      assert_raise Ecto.QueryError, error_message, fn ->
+        combination_query |> offset(10) |> all()
+      end
+    end
+
+    query =
+      base_query
+      |> union_all(^other_query)
+      |> subquery()
+      |> select([r], r.x)
+      |> limit(5)
+      |> offset(10)
+
+    assert all(query) ==
+             ~s[SELECT s0."x" FROM (SELECT ss0."x" AS "x" FROM "schema" AS ss0 UNION ALL (SELECT s0."y" FROM "schema" AS s0)) AS s0 LIMIT 5 OFFSET 10]
   end
 
   test "except and except all" do
@@ -658,8 +692,6 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
       Schema
       |> select([r], r.x)
       |> order_by(fragment("rand()"))
-      |> offset(10)
-      |> limit(5)
 
     except_query1 =
       Schema
@@ -682,7 +714,7 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
 
     assert all(query) ==
              """
-             SELECT s0."x" FROM "schema" AS s0 ORDER BY rand() LIMIT 5 OFFSET 10 \
+             SELECT s0."x" FROM "schema" AS s0 ORDER BY rand() \
              EXCEPT (SELECT s0."y" FROM "schema" AS s0 ORDER BY s0."y" LIMIT 40 OFFSET 20) \
              EXCEPT (SELECT s0."z" FROM "schema" AS s0 ORDER BY s0."z" LIMIT 60 OFFSET 30)\
              """
@@ -700,8 +732,6 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
       Schema
       |> select([r], r.x)
       |> order_by(fragment("rand()"))
-      |> offset(10)
-      |> limit(5)
 
     intersect_query1 =
       Schema
@@ -724,7 +754,7 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
 
     assert all(query) ==
              """
-             SELECT s0."x" FROM "schema" AS s0 ORDER BY rand() LIMIT 5 OFFSET 10 \
+             SELECT s0."x" FROM "schema" AS s0 ORDER BY rand() \
              INTERSECT (SELECT s0."y" FROM "schema" AS s0 ORDER BY s0."y" LIMIT 40 OFFSET 20) \
              INTERSECT (SELECT s0."z" FROM "schema" AS s0 ORDER BY s0."z" LIMIT 60 OFFSET 30)\
              """
@@ -1183,8 +1213,6 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
       |> union(^union)
       |> union_all(^union_all)
       |> order_by([], fragment("?", ^7))
-      |> limit([], ^8)
-      |> offset([], ^9)
 
     assert all(query) ==
              """
@@ -1203,8 +1231,6 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
              GROUP BY {$8:Int64},{$9:Int64} \
              HAVING ({$10:Bool}) AND ({$11:Bool}) \
              ORDER BY {$16:Int64} \
-             LIMIT {$17:Int64} \
-             OFFSET {$18:Int64} \
              UNION DISTINCT \
              (SELECT s0."id",{$12:Bool} FROM "schema1" AS s0 \
              WHERE ({$13:Int64})) \

--- a/test/ecto/integration/inline_test.exs
+++ b/test/ecto/integration/inline_test.exs
@@ -46,8 +46,6 @@ defmodule Ecto.Integration.InlineSQLTest do
         |> union(^union)
         |> union_all(^union_all)
         |> order_by([], fragment("?", ^7))
-        |> limit([], ^8)
-        |> offset([], ^9)
 
       assert TestRepo.to_inline_sql(:all, query) ==
                """
@@ -66,8 +64,6 @@ defmodule Ecto.Integration.InlineSQLTest do
                GROUP BY 3,4 \
                HAVING (true) AND (false) \
                ORDER BY 7 \
-               LIMIT 8 \
-               OFFSET 9 \
                UNION DISTINCT \
                (SELECT s0."id",true FROM "schema1" AS s0 \
                WHERE (5)) \

--- a/test/ecto/integration/union_test.exs
+++ b/test/ecto/integration/union_test.exs
@@ -33,6 +33,33 @@ defmodule Ecto.Integration.UnionTest do
     assert Enum.sort(data) == Enum.sort(["bye", "hello"])
   end
 
+  test "limit and offset a union through a subquery" do
+    TestRepo.insert!(%Post{title: "hello", counter: 1, public: true})
+    TestRepo.insert!(%Post{title: "morning", counter: 2, public: true})
+    TestRepo.insert!(%Post{title: "bye", counter: 3, public: false})
+
+    public =
+      from p in Post,
+        where: p.public,
+        select: %{title: p.title, counter: p.counter}
+
+    private =
+      from p in Post,
+        where: not p.public,
+        select: %{title: p.title, counter: p.counter}
+
+    query =
+      public
+      |> union_all(^private)
+      |> subquery()
+      |> order_by([p], p.counter)
+      |> limit(1)
+      |> offset(1)
+      |> select([p], p.title)
+
+    assert TestRepo.all(query) == ["morning"]
+  end
+
   test "union & params" do
     TestRepo.insert!(%Post{title: "hello", counter: 1, public: true})
     TestRepo.insert!(%Post{title: "morning", counter: 2, public: true})
@@ -63,38 +90,34 @@ defmodule Ecto.Integration.UnionTest do
     bye =
       from p in Post,
         where: p.public == ^false,
-        order_by: :counter,
-        limit: ^1,
         select: p.title
 
     query =
-      hello_and_morning
+      bye
+      |> union_all(^hello_and_morning)
       |> union_all(^morning_1)
-      |> union_all(^bye)
       |> union_all(^morning_2)
 
     {sql, params} = TestRepo.to_sql(:all, query)
 
-    # ensures param idx=8 is 2 (from limit: ^2 above)
-    assert Enum.at(params, 8) == 2
+    # ensures param idx=2 is 2 (from limit: ^2 above)
+    assert Enum.at(params, 2) == 2
 
     assert sql == """
            SELECT p0."title" FROM "posts" AS p0 \
            WHERE (p0."public" = {$0:Bool}) \
-           ORDER BY p0."counter" \
-           LIMIT {$8:Int64} \
            UNION ALL \
            (\
            SELECT p0."title" FROM "posts" AS p0 \
            WHERE (p0."public" = {$1:Bool}) \
-           ORDER BY p0."counter" DESC \
+           ORDER BY p0."counter" \
            LIMIT {$2:Int64}\
            ) \
            UNION ALL \
            (\
            SELECT p0."title" FROM "posts" AS p0 \
            WHERE (p0."public" = {$3:Bool}) \
-           ORDER BY p0."counter" \
+           ORDER BY p0."counter" DESC \
            LIMIT {$4:Int64}\
            ) \
            UNION ALL \


### PR DESCRIPTION
ClickHouse applies `LIMIT` and `OFFSET` to each `SELECT` in a combination, so Ecto parent clauses can otherwise produce silently incorrect result sets.

This raises `Ecto.QueryError` for parent limits or offsets on `UNION`, `EXCEPT`, and `INTERSECT` queries and directs callers to wrap the combination in `subquery/1`.

Unit and integration coverage verify both rejection and the supported subquery workaround while preserving per-branch limits.

Validated with formatting, warnings-as-errors compilation, and 490 passing tests/doctests; closes #38.
