### PR TITLE
Stabilize VALUES SQL order test (fix flaky test)

### DIFF
--- a/test/ecto/adapters/clickhouse/connection_test.exs
+++ b/test/ecto/adapters/clickhouse/connection_test.exs
@@ -901,13 +901,22 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
         where: v1.num == ^2
       )
 
-    assert all(query) ==
+    # Ecto derives the fields from a MapSet, whose enumeration order is unspecified.
+    # In either order, the VALUES structure and parameter types must stay aligned.
+    assert all(query) in [
              """
              SELECT v1."bid",v1."num" \
              FROM VALUES('bid UUID,num Int64',({$0:String},{$1:Int64}),({$2:String},{$3:Int64})) AS v0 \
              INNER JOIN VALUES('bid UUID,num Int64',({$4:String},{$5:Int64}),({$6:String},{$7:Int64})) AS v1 ON v0."bid" = v1."bid" \
              WHERE (v0."num" = {$8:Int64})\
+             """,
              """
+             SELECT v1."num",v1."bid" \
+             FROM VALUES('num Int64,bid UUID',({$0:Int64},{$1:String}),({$2:Int64},{$3:String})) AS v0 \
+             INNER JOIN VALUES('num Int64,bid UUID',({$4:Int64},{$5:String}),({$6:Int64},{$7:String})) AS v1 ON v0."bid" = v1."bid" \
+             WHERE (v0."num" = {$8:Int64})\
+             """
+           ]
   end
 
   test "literals" do


### PR DESCRIPTION
Ecto derives `values/2` fields from a `MapSet`, so their enumeration order is unspecified and can vary across runtime versions. This updates the compiler test to accept both valid field orders while still asserting that the `VALUES` column structure, selected fields, and typed parameter positions remain aligned. The adapter continues preserving Ecto’s planned order, avoiding unsafe independent sorting and parameter remapping. Validated with `mix test test/ecto/adapters/clickhouse/connection_test.exs` (184 passed, 4 skipped).