### PR TITLE
Standardize ClickHouse quoting

### DIFF
--- a/lib/ecto/adapters/clickhouse/connection.ex
+++ b/lib/ecto/adapters/clickhouse/connection.ex
@@ -754,7 +754,7 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
 
     structure =
       Enum.map_intersperse(types, ?,, fn {field, type} ->
-        [escape_string(Atom.to_string(field)), ?\s, ecto_to_db(type, query)]
+        [Atom.to_string(field), ?\s, ecto_to_db(type, query)]
       end)
 
     {rows, _idx} =
@@ -763,7 +763,7 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
         {[?(, value, ?)], idx}
       end)
 
-    ["VALUES('", structure, ?', ?,, rows, ?)]
+    ["VALUES(", quote_string(structure), ?,, rows, ?)]
   end
 
   defp expr({:identifier, _, [name]}, _sources, _params, _query) do
@@ -771,7 +771,7 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
   end
 
   defp expr({:constant, _, [literal]}, _sources, _params, _query) when is_binary(literal) do
-    [?', escape_string(literal), ?']
+    quote_string(literal)
   end
 
   defp expr({:constant, _, [literal]}, _sources, _params, _query) when is_number(literal) do
@@ -832,7 +832,7 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
   defp expr({:json_extract_path, _, [expr, path]}, sources, params, query) do
     path =
       Enum.map(path, fn
-        bin when is_binary(bin) -> [?., json_path_key(bin)]
+        bin when is_binary(bin) -> [?., quote_name(bin, ?`)]
         int when is_integer(int) -> [?[, Integer.to_string(int), ?]]
       end)
 
@@ -887,7 +887,7 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
   defp expr(false, _sources, _params, _query), do: "0"
 
   defp expr(literal, _sources, _params, _query) when is_binary(literal) do
-    [?', escape_string(literal), ?']
+    quote_string(literal)
   end
 
   defp expr(literal, _sources, _params, _query) when is_integer(literal) do
@@ -1030,25 +1030,27 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
 
   @doc false
   def quote_name(name, quoter \\ ?")
-  def quote_name(nil, _), do: []
+  def quote_name(nil, quoter) when quoter in [?\", ?`], do: []
 
-  def quote_name(names, quoter) when is_list(names) do
+  def quote_name(name, quoter) when quoter in [?\", ?`] do
+    name
+    |> unquoted_name()
+    |> quote_with(quoter)
+  end
+
+  @doc false
+  def quote_string(value) do
+    quote_with(value, ?')
+  end
+
+  defp unquoted_name(names) when is_list(names) do
     names
     |> Enum.reject(&is_nil/1)
-    |> intersperse_map(?., &quote_name(&1, nil))
-    |> escape_quoted(quoter)
-    |> wrap_in(quoter)
+    |> intersperse_map(?., &unquoted_name/1)
   end
 
-  def quote_name(name, quoter) when is_atom(name) do
-    name |> Atom.to_string() |> quote_name(quoter)
-  end
-
-  def quote_name(name, quoter) do
-    name
-    |> escape_quoted(quoter)
-    |> wrap_in(quoter)
-  end
+  defp unquoted_name(name) when is_atom(name), do: Atom.to_string(name)
+  defp unquoted_name(name), do: name
 
   defp quote_qualified_name(name, sources, ix) do
     {_, source, _} = elem(sources, ix)
@@ -1064,34 +1066,18 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
   def quote_table(nil, name), do: quote_name(name)
   def quote_table(prefix, name), do: [quote_name(prefix), ?., quote_name(name)]
 
-  defp wrap_in(value, nil), do: value
-  defp wrap_in(value, wrapper), do: [wrapper, value, wrapper]
+  defp quote_with(value, quoter) do
+    [quoter, escape_quoted(value, quoter), quoter]
+  end
 
-  defp escape_quoted(value, nil), do: value
-  defp escape_quoted(value, ?'), do: escape_string(IO.iodata_to_binary(value))
-
-  defp escape_quoted(value, quoter) when quoter in [?\", ?`] do
+  defp escape_quoted(value, quoter) when quoter in [?', ?\", ?`] do
     # Neutralize existing escape sequences before escaping the active delimiter.
+    escaped_quoter = if quoter == ?', do: "''", else: <<?\\, quoter>>
+
     value
     |> IO.iodata_to_binary()
     |> :binary.replace("\\", "\\\\", [:global])
-    |> :binary.replace(<<quoter>>, "\\" <> <<quoter>>, [:global])
-  end
-
-  @doc false
-  # TODO faster?
-  def escape_string(value) when is_binary(value) do
-    value
-    |> :binary.replace("'", "''", [:global])
-    |> :binary.replace("\\", "\\\\", [:global])
-  end
-
-  defp json_path_key(value) when is_binary(value) do
-    if Regex.match?(~r/^[A-Za-z_][A-Za-z0-9_]*$/, value) do
-      value
-    else
-      quote_name(value, ?`)
-    end
+    |> :binary.replace(<<quoter>>, escaped_quoter, [:global])
   end
 
   defp get_source(query, sources, params, ix, source) do
@@ -1147,7 +1133,7 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
   defp inline_param(nil), do: "NULL"
   defp inline_param(true), do: "true"
   defp inline_param(false), do: "false"
-  defp inline_param(s) when is_binary(s), do: [?', escape_string(s), ?']
+  defp inline_param(s) when is_binary(s), do: quote_string(s)
 
   @max_uint128 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
   @max_uint64 0xFFFFFFFFFFFFFFFF
@@ -1172,21 +1158,27 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
     naive = NaiveDateTime.to_string(naive)
 
     case microsecond do
-      {0, 0} -> [?', naive, "'::datetime"]
-      {_, precision} -> [?', naive, "'::DateTime64(", Integer.to_string(precision), ?)]
+      {0, 0} -> [quote_string(naive), "::datetime"]
+      {_, precision} -> [quote_string(naive), "::DateTime64(", Integer.to_string(precision), ?)]
     end
   end
 
   defp inline_param(%DateTime{microsecond: microsecond, time_zone: time_zone} = dt) do
-    time_zone = escape_string(time_zone)
     dt = NaiveDateTime.to_string(DateTime.to_naive(dt))
 
     case microsecond do
       {0, 0} ->
-        [?', dt, "'::DateTime('", time_zone, "')"]
+        [quote_string(dt), "::DateTime(", quote_string(time_zone), ?)]
 
       {_, precision} ->
-        [?', dt, "'::DateTime64(", Integer.to_string(precision), ",'", time_zone, "')"]
+        [
+          quote_string(dt),
+          "::DateTime64(",
+          Integer.to_string(precision),
+          ?,,
+          quote_string(time_zone),
+          ?)
+        ]
     end
   end
 

--- a/lib/ecto/adapters/clickhouse/migration.ex
+++ b/lib/ecto/adapters/clickhouse/migration.ex
@@ -268,7 +268,7 @@ defmodule Ecto.Adapters.ClickHouse.Migration do
 
   defp comment(%Table{} = table) do
     if comment = table.comment do
-      [" COMMENT ", @conn.quote_name(comment, ?')]
+      [" COMMENT ", @conn.quote_string(comment)]
     else
       []
     end
@@ -381,7 +381,7 @@ defmodule Ecto.Adapters.ClickHouse.Migration do
   defp null_expr(_), do: []
 
   defp comment_expr(nil), do: []
-  defp comment_expr(comment), do: [" COMMENT '", @conn.escape_string(comment), ?']
+  defp comment_expr(comment), do: [" COMMENT ", @conn.quote_string(comment)]
 
   @dialyzer {:no_improper_lists, default_expr: 2}
   defp default_expr({:ok, nil}, _type) do
@@ -389,7 +389,7 @@ defmodule Ecto.Adapters.ClickHouse.Migration do
   end
 
   defp default_expr({:ok, literal}, _type) when is_binary(literal) do
-    [" DEFAULT '", @conn.escape_string(literal), ?']
+    [" DEFAULT ", @conn.quote_string(literal)]
   end
 
   defp default_expr({:ok, literal}, _type) when is_number(literal) do

--- a/test/ecto/adapters/clickhouse/connection_test.exs
+++ b/test/ecto/adapters/clickhouse/connection_test.exs
@@ -825,17 +825,27 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
     assert query == ~s{INSERT INTO "schema\\"quoted"("field\\"quoted")}
   end
 
-  test "quoted identifier escape matches the byte-wise oracle for every byte pair" do
+  test "quoted values match the byte-wise oracle for every byte pair" do
     value = for left <- 0..255, right <- 0..255, into: <<>>, do: <<left, right>>
 
-    for quoter <- [?", ?`] do
+    for quoter <- [?', ?", ?`] do
       expected =
         for <<byte <- value>>, into: <<>> do
-          if byte in [?\\, quoter], do: <<?\\, byte>>, else: <<byte>>
+          cond do
+            byte == ?\\ -> <<?\\, ?\\>>
+            byte == ?' and quoter == ?' -> <<?', ?'>>
+            byte == quoter -> <<?\\, byte>>
+            true -> <<byte>>
+          end
         end
 
-      assert Connection.quote_name(value, quoter) |> IO.iodata_to_binary() ==
-               <<quoter, expected::binary, quoter>>
+      quoted =
+        case quoter do
+          ?' -> Connection.quote_string(value)
+          quoter -> Connection.quote_name(value, quoter)
+        end
+
+      assert IO.iodata_to_binary(quoted) == <<quoter, expected::binary, quoter>>
     end
   end
 
@@ -1063,7 +1073,10 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
     assert all(query) == ~s{SELECT s0."meta"[0][1] FROM "schema" AS s0}
 
     query = Schema |> select([s], json_extract_path(s.meta, ["a", "b"]))
-    assert all(query) == ~s{SELECT s0."meta".a.b FROM "schema" AS s0}
+    assert all(query) == ~s{SELECT s0."meta".`a`.`b` FROM "schema" AS s0}
+
+    query = Schema |> select([s], json_extract_path(s.meta, ["FROM"]))
+    assert all(query) == ~s{SELECT s0."meta".`FROM` FROM "schema" AS s0}
 
     query = Schema |> select([s], json_extract_path(s.meta, ["'a"]))
     assert all(query) == ~s{SELECT s0."meta".`'a` FROM "schema" AS s0}
@@ -1078,7 +1091,7 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
     assert all(query) == ~S|SELECT s0."meta".`a\\b` FROM "schema" AS s0|
 
     query = Schema |> select([s], s.meta["author"]["name"])
-    assert all(query) == ~s{SELECT s0."meta".author.name FROM "schema" AS s0}
+    assert all(query) == ~s{SELECT s0."meta".`author`.`name` FROM "schema" AS s0}
   end
 
   test "nested expressions" do

--- a/test/ecto/integration/json_test.exs
+++ b/test/ecto/integration/json_test.exs
@@ -88,6 +88,7 @@ defmodule Ecto.Integration.JsonTest do
     TestRepo.insert_all(SemiStructured, [
       %{
         json: %{
+          "FROM" => "keyword",
           "from" => "insert_all",
           "nested" => %{"name" => "Test", "arr" => ["abc", "b=deb"]},
           "edge cases" => %{
@@ -112,6 +113,7 @@ defmodule Ecto.Integration.JsonTest do
     assert TestRepo.all(
              from s in SemiStructured,
                select: %{
+                 keyword: json_extract_path(s.json, ["FROM"]),
                  from: json_extract_path(s.json, ["from"]),
                  name: json_extract_path(s.json, ["nested", "name"]),
                  edge_space: json_extract_path(s.json, ["edge cases", "space key"]),
@@ -130,6 +132,7 @@ defmodule Ecto.Integration.JsonTest do
                }
            ) == [
              %{
+               keyword: "keyword",
                from: "insert_all",
                name: "Test",
                edge_space: "space",

--- a/test/ecto/integration/sql_test.exs
+++ b/test/ecto/integration/sql_test.exs
@@ -59,7 +59,7 @@ defmodule Ecto.Integration.SQLTest do
 
   test "quoted strings and identifiers cannot break out into ClickHouse syntax" do
     string = ~S|value' FROM numbers(10) -- \ $tag$body$tag$ /* comment */|
-    result = TestRepo.query!(["SELECT ", Connection.quote_name(string, ?')])
+    result = TestRepo.query!(["SELECT ", Connection.quote_string(string)])
 
     assert result.rows == [[string]]
 


### PR DESCRIPTION
Separates identifier quoting (`quote_name/2`) from string-literal quoting (`quote_string/1`) while routing both through one escape-and-wrap implementation.

It updates query and migration emitters to consume complete quoted literals, removing manual delimiter assembly and preserving ClickHouse quote and backslash semantics.

JSON path segments are now always backtick-quoted, removing a regex that accepted keyword-shaped keys such as `FROM` and avoiding a duplicate identifier classifier.

Validation: `MIX_ENV=test mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix test` (498 passed, 82 skipped), and `mix dialyzer --format github`.
