### PR TITLE
Standardize ClickHouse quoting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Standardize escaping for single-quoted strings, double-quoted and backtick-quoted identifiers, and JSON path keys https://github.com/plausible/ecto_ch/pull/304
 - Use `Date32` for bound date parameters before 1970 or after 2148 https://github.com/plausible/ecto_ch/pull/307
 - Fix explicit `type/2` casts for `:naive_datetime`, `:utc_datetime`, their microsecond variants, and `:binary_id` https://github.com/plausible/ecto_ch/pull/306
 - Raise an explicit error for the unsupported Ecto `:bitstring` type https://github.com/plausible/ecto_ch/pull/305

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Standardize escaping for single-quoted strings, double-quoted and backtick-quoted identifiers, and JSON path keys https://github.com/plausible/ecto_ch/pull/304
+- Standardize escaping for single-quoted strings and double-quoted identifiers, including JSON path keys https://github.com/plausible/ecto_ch/pull/304
 - Use `Date32` for bound date parameters before 1970 or after 2148 https://github.com/plausible/ecto_ch/pull/307
 - Fix explicit `type/2` casts for `:naive_datetime`, `:utc_datetime`, their microsecond variants, and `:binary_id` https://github.com/plausible/ecto_ch/pull/306
 - Raise an explicit error for the unsupported Ecto `:bitstring` type https://github.com/plausible/ecto_ch/pull/305

--- a/lib/ecto/adapters/clickhouse/connection.ex
+++ b/lib/ecto/adapters/clickhouse/connection.ex
@@ -1033,7 +1033,7 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
 
   def quote_name(name) do
     name
-    |> unquoted_name()
+    |> name_to_iodata()
     |> quote_with(?")
   end
 
@@ -1042,14 +1042,14 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
     quote_with(value, ?')
   end
 
-  defp unquoted_name(names) when is_list(names) do
+  defp name_to_iodata(names) when is_list(names) do
     names
     |> Enum.reject(&is_nil/1)
-    |> intersperse_map(?., &unquoted_name/1)
+    |> intersperse_map(?., &name_to_iodata/1)
   end
 
-  defp unquoted_name(name) when is_atom(name), do: Atom.to_string(name)
-  defp unquoted_name(name) when is_binary(name), do: name
+  defp name_to_iodata(name) when is_atom(name), do: Atom.to_string(name)
+  defp name_to_iodata(name) when is_binary(name), do: name
 
   defp quote_qualified_name(name, sources, ix) do
     {_, source, _} = elem(sources, ix)

--- a/lib/ecto/adapters/clickhouse/connection.ex
+++ b/lib/ecto/adapters/clickhouse/connection.ex
@@ -753,9 +753,11 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
     rows = :lists.seq(1, num_rows, 1)
 
     structure =
-      Enum.map_intersperse(types, ?,, fn {field, type} ->
+      types
+      |> Enum.map_intersperse(?,, fn {field, type} ->
         [Atom.to_string(field), ?\s, ecto_to_db(type, query)]
       end)
+      |> IO.iodata_to_binary()
 
     {rows, _idx} =
       intersperse_reduce(rows, ?,, idx, fn _, idx ->
@@ -1034,11 +1036,12 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
   def quote_name(name) do
     name
     |> name_to_iodata()
+    |> IO.iodata_to_binary()
     |> quote_with(?")
   end
 
   @doc false
-  def quote_string(value) do
+  def quote_string(value) when is_binary(value) do
     quote_with(value, ?')
   end
 
@@ -1065,17 +1068,16 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
   def quote_table(nil, name), do: quote_name(name)
   def quote_table(prefix, name), do: [quote_name(prefix), ?., quote_name(name)]
 
-  defp quote_with(value, quoter) do
+  defp quote_with(value, quoter) when is_binary(value) and quoter in [?', ?\"] do
     [quoter, escape_quoted(value, quoter), quoter]
   end
 
-  defp escape_quoted(value, quoter) when quoter in [?', ?\"] do
+  defp escape_quoted(value, quoter) when is_binary(value) and quoter in [?', ?\"] do
     # Neutralize existing escape sequences before escaping the active delimiter.
     # ClickHouse accepts both '' and \'; emit SQL-style doubling canonically.
     escaped_quoter = if quoter == ?', do: "''", else: <<?\\, quoter>>
 
     value
-    |> IO.iodata_to_binary()
     |> :binary.replace("\\", "\\\\", [:global])
     |> :binary.replace(<<quoter>>, escaped_quoter, [:global])
   end

--- a/lib/ecto/adapters/clickhouse/connection.ex
+++ b/lib/ecto/adapters/clickhouse/connection.ex
@@ -754,7 +754,7 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
 
     structure =
       Enum.map_intersperse(types, ?,, fn {field, type} ->
-        [escape_string(Atom.to_string(field)), ?\s, ecto_to_db(type, query)]
+        [Atom.to_string(field), ?\s, ecto_to_db(type, query)]
       end)
 
     {rows, _idx} =
@@ -763,7 +763,7 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
         {[?(, value, ?)], idx}
       end)
 
-    ["VALUES('", structure, ?', ?,, rows, ?)]
+    ["VALUES(", quote_string(structure), ?,, rows, ?)]
   end
 
   defp expr({:identifier, _, [name]}, _sources, _params, _query) do
@@ -771,7 +771,7 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
   end
 
   defp expr({:constant, _, [literal]}, _sources, _params, _query) when is_binary(literal) do
-    [?', escape_string(literal), ?']
+    quote_string(literal)
   end
 
   defp expr({:constant, _, [literal]}, _sources, _params, _query) when is_number(literal) do
@@ -832,7 +832,7 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
   defp expr({:json_extract_path, _, [expr, path]}, sources, params, query) do
     path =
       Enum.map(path, fn
-        bin when is_binary(bin) -> [?., json_path_key(bin)]
+        bin when is_binary(bin) -> [?., quote_name(bin, ?`)]
         int when is_integer(int) -> [?[, Integer.to_string(int), ?]]
       end)
 
@@ -887,7 +887,7 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
   defp expr(false, _sources, _params, _query), do: "0"
 
   defp expr(literal, _sources, _params, _query) when is_binary(literal) do
-    [?', escape_string(literal), ?']
+    quote_string(literal)
   end
 
   defp expr(literal, _sources, _params, _query) when is_integer(literal) do
@@ -1030,25 +1030,27 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
 
   @doc false
   def quote_name(name, quoter \\ ?")
-  def quote_name(nil, _), do: []
+  def quote_name(nil, quoter) when quoter in [?\", ?`], do: []
 
-  def quote_name(names, quoter) when is_list(names) do
+  def quote_name(name, quoter) when quoter in [?\", ?`] do
+    name
+    |> unquoted_name()
+    |> quote_with(quoter)
+  end
+
+  @doc false
+  def quote_string(value) do
+    quote_with(value, ?')
+  end
+
+  defp unquoted_name(names) when is_list(names) do
     names
     |> Enum.reject(&is_nil/1)
-    |> intersperse_map(?., &quote_name(&1, nil))
-    |> escape_quoted(quoter)
-    |> wrap_in(quoter)
+    |> intersperse_map(?., &unquoted_name/1)
   end
 
-  def quote_name(name, quoter) when is_atom(name) do
-    name |> Atom.to_string() |> quote_name(quoter)
-  end
-
-  def quote_name(name, quoter) do
-    name
-    |> escape_quoted(quoter)
-    |> wrap_in(quoter)
-  end
+  defp unquoted_name(name) when is_atom(name), do: Atom.to_string(name)
+  defp unquoted_name(name), do: name
 
   defp quote_qualified_name(name, sources, ix) do
     {_, source, _} = elem(sources, ix)
@@ -1064,34 +1066,18 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
   def quote_table(nil, name), do: quote_name(name)
   def quote_table(prefix, name), do: [quote_name(prefix), ?., quote_name(name)]
 
-  defp wrap_in(value, nil), do: value
-  defp wrap_in(value, wrapper), do: [wrapper, value, wrapper]
+  defp quote_with(value, quoter) do
+    [quoter, escape_quoted(value, quoter), quoter]
+  end
 
-  defp escape_quoted(value, nil), do: value
-  defp escape_quoted(value, ?'), do: escape_string(IO.iodata_to_binary(value))
-
-  defp escape_quoted(value, quoter) when quoter in [?\", ?`] do
+  defp escape_quoted(value, quoter) when quoter in [?', ?\", ?`] do
     # Neutralize existing escape sequences before escaping the active delimiter.
+    escaped_quoter = if quoter == ?', do: "''", else: <<?\\, quoter>>
+
     value
     |> IO.iodata_to_binary()
     |> :binary.replace("\\", "\\\\", [:global])
-    |> :binary.replace(<<quoter>>, "\\" <> <<quoter>>, [:global])
-  end
-
-  @doc false
-  # TODO faster?
-  def escape_string(value) when is_binary(value) do
-    value
-    |> :binary.replace("'", "''", [:global])
-    |> :binary.replace("\\", "\\\\", [:global])
-  end
-
-  defp json_path_key(value) when is_binary(value) do
-    if Regex.match?(~r/^[A-Za-z_][A-Za-z0-9_]*$/, value) do
-      value
-    else
-      quote_name(value, ?`)
-    end
+    |> :binary.replace(<<quoter>>, escaped_quoter, [:global])
   end
 
   defp get_source(query, sources, params, ix, source) do
@@ -1156,7 +1142,7 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
   defp inline_param(nil), do: "NULL"
   defp inline_param(true), do: "true"
   defp inline_param(false), do: "false"
-  defp inline_param(s) when is_binary(s), do: [?', escape_string(s), ?']
+  defp inline_param(s) when is_binary(s), do: quote_string(s)
 
   @max_uint128 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
   @max_uint64 0xFFFFFFFFFFFFFFFF
@@ -1181,21 +1167,27 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
     naive = NaiveDateTime.to_string(naive)
 
     case microsecond do
-      {0, 0} -> [?', naive, "'::datetime"]
-      {_, precision} -> [?', naive, "'::DateTime64(", Integer.to_string(precision), ?)]
+      {0, 0} -> [quote_string(naive), "::datetime"]
+      {_, precision} -> [quote_string(naive), "::DateTime64(", Integer.to_string(precision), ?)]
     end
   end
 
   defp inline_param(%DateTime{microsecond: microsecond, time_zone: time_zone} = dt) do
-    time_zone = escape_string(time_zone)
     dt = NaiveDateTime.to_string(DateTime.to_naive(dt))
 
     case microsecond do
       {0, 0} ->
-        [?', dt, "'::DateTime('", time_zone, "')"]
+        [quote_string(dt), "::DateTime(", quote_string(time_zone), ?)]
 
       {_, precision} ->
-        [?', dt, "'::DateTime64(", Integer.to_string(precision), ",'", time_zone, "')"]
+        [
+          quote_string(dt),
+          "::DateTime64(",
+          Integer.to_string(precision),
+          ?,,
+          quote_string(time_zone),
+          ?)
+        ]
     end
   end
 

--- a/lib/ecto/adapters/clickhouse/connection.ex
+++ b/lib/ecto/adapters/clickhouse/connection.ex
@@ -754,7 +754,7 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
 
     structure =
       Enum.map_intersperse(types, ?,, fn {field, type} ->
-        [escape_string(Atom.to_string(field)), ?\s, ecto_to_db(type, query)]
+        [Atom.to_string(field), ?\s, ecto_to_db(type, query)]
       end)
 
     {rows, _idx} =
@@ -763,7 +763,7 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
         {[?(, value, ?)], idx}
       end)
 
-    ["VALUES('", structure, ?', ?,, rows, ?)]
+    ["VALUES(", quote_string(structure), ?,, rows, ?)]
   end
 
   defp expr({:identifier, _, [name]}, _sources, _params, _query) do
@@ -771,7 +771,7 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
   end
 
   defp expr({:constant, _, [literal]}, _sources, _params, _query) when is_binary(literal) do
-    [?', escape_string(literal), ?']
+    quote_string(literal)
   end
 
   defp expr({:constant, _, [literal]}, _sources, _params, _query) when is_number(literal) do
@@ -832,7 +832,7 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
   defp expr({:json_extract_path, _, [expr, path]}, sources, params, query) do
     path =
       Enum.map(path, fn
-        bin when is_binary(bin) -> [?., json_path_key(bin)]
+        bin when is_binary(bin) -> [?., quote_name(bin, ?`)]
         int when is_integer(int) -> [?[, Integer.to_string(int), ?]]
       end)
 
@@ -887,7 +887,7 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
   defp expr(false, _sources, _params, _query), do: "0"
 
   defp expr(literal, _sources, _params, _query) when is_binary(literal) do
-    [?', escape_string(literal), ?']
+    quote_string(literal)
   end
 
   defp expr(literal, _sources, _params, _query) when is_integer(literal) do
@@ -1030,25 +1030,27 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
 
   @doc false
   def quote_name(name, quoter \\ ?")
-  def quote_name(nil, _), do: []
+  def quote_name(nil, quoter) when quoter in [?\", ?`], do: []
 
-  def quote_name(names, quoter) when is_list(names) do
+  def quote_name(name, quoter) when quoter in [?\", ?`] do
+    name
+    |> unquoted_name()
+    |> quote_with(quoter)
+  end
+
+  @doc false
+  def quote_string(value) do
+    quote_with(value, ?')
+  end
+
+  defp unquoted_name(names) when is_list(names) do
     names
     |> Enum.reject(&is_nil/1)
-    |> intersperse_map(?., &quote_name(&1, nil))
-    |> escape_quoted(quoter)
-    |> wrap_in(quoter)
+    |> intersperse_map(?., &unquoted_name/1)
   end
 
-  def quote_name(name, quoter) when is_atom(name) do
-    name |> Atom.to_string() |> quote_name(quoter)
-  end
-
-  def quote_name(name, quoter) do
-    name
-    |> escape_quoted(quoter)
-    |> wrap_in(quoter)
-  end
+  defp unquoted_name(name) when is_atom(name), do: Atom.to_string(name)
+  defp unquoted_name(name), do: name
 
   defp quote_qualified_name(name, sources, ix) do
     {_, source, _} = elem(sources, ix)
@@ -1064,34 +1066,18 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
   def quote_table(nil, name), do: quote_name(name)
   def quote_table(prefix, name), do: [quote_name(prefix), ?., quote_name(name)]
 
-  defp wrap_in(value, nil), do: value
-  defp wrap_in(value, wrapper), do: [wrapper, value, wrapper]
+  defp quote_with(value, quoter) do
+    [quoter, escape_quoted(value, quoter), quoter]
+  end
 
-  defp escape_quoted(value, nil), do: value
-  defp escape_quoted(value, ?'), do: escape_string(IO.iodata_to_binary(value))
-
-  defp escape_quoted(value, quoter) when quoter in [?\", ?`] do
+  defp escape_quoted(value, quoter) when quoter in [?', ?\", ?`] do
     # Neutralize existing escape sequences before escaping the active delimiter.
+    escaped_quoter = if quoter == ?', do: "''", else: <<?\\, quoter>>
+
     value
     |> IO.iodata_to_binary()
     |> :binary.replace("\\", "\\\\", [:global])
-    |> :binary.replace(<<quoter>>, "\\" <> <<quoter>>, [:global])
-  end
-
-  @doc false
-  # TODO faster?
-  def escape_string(value) when is_binary(value) do
-    value
-    |> :binary.replace("'", "''", [:global])
-    |> :binary.replace("\\", "\\\\", [:global])
-  end
-
-  defp json_path_key(value) when is_binary(value) do
-    if Regex.match?(~r/^[A-Za-z_][A-Za-z0-9_]*$/, value) do
-      value
-    else
-      quote_name(value, ?`)
-    end
+    |> :binary.replace(<<quoter>>, escaped_quoter, [:global])
   end
 
   defp get_source(query, sources, params, ix, source) do
@@ -1147,7 +1133,7 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
   defp inline_param(nil), do: "NULL"
   defp inline_param(true), do: "true"
   defp inline_param(false), do: "false"
-  defp inline_param(s) when is_binary(s), do: [?', escape_string(s), ?']
+  defp inline_param(s) when is_binary(s), do: quote_string(s)
 
   @max_uint128 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
   @max_uint64 0xFFFFFFFFFFFFFFFF
@@ -1172,21 +1158,27 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
     naive = NaiveDateTime.to_string(naive)
 
     case microsecond do
-      {0, 0} -> [?', naive, "'::datetime"]
-      {_, precision} -> [?', naive, "'::DateTime64(", Integer.to_string(precision), ?)]
+      {0, 0} -> [quote_string(naive), "::datetime"]
+      {_, precision} -> [quote_string(naive), "::DateTime64(", Integer.to_string(precision), ?)]
     end
   end
 
   defp inline_param(%DateTime{microsecond: microsecond, time_zone: time_zone} = dt) do
-    time_zone = escape_string(time_zone)
     dt = NaiveDateTime.to_string(DateTime.to_naive(dt))
 
     case microsecond do
       {0, 0} ->
-        [?', dt, "'::DateTime('", time_zone, "')"]
+        [quote_string(dt), "::DateTime(", quote_string(time_zone), ?)]
 
       {_, precision} ->
-        [?', dt, "'::DateTime64(", Integer.to_string(precision), ",'", time_zone, "')"]
+        [
+          quote_string(dt),
+          "::DateTime64(",
+          Integer.to_string(precision),
+          ?,,
+          quote_string(time_zone),
+          ?)
+        ]
     end
   end
 

--- a/lib/ecto/adapters/clickhouse/connection.ex
+++ b/lib/ecto/adapters/clickhouse/connection.ex
@@ -1050,7 +1050,7 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
   end
 
   defp unquoted_name(name) when is_atom(name), do: Atom.to_string(name)
-  defp unquoted_name(name), do: name
+  defp unquoted_name(name) when is_binary(name), do: name
 
   defp quote_qualified_name(name, sources, ix) do
     {_, source, _} = elem(sources, ix)
@@ -1072,6 +1072,7 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
 
   defp escape_quoted(value, quoter) when quoter in [?', ?\", ?`] do
     # Neutralize existing escape sequences before escaping the active delimiter.
+    # ClickHouse accepts both '' and \'; emit SQL-style doubling canonically.
     escaped_quoter = if quoter == ?', do: "''", else: <<?\\, quoter>>
 
     value

--- a/lib/ecto/adapters/clickhouse/connection.ex
+++ b/lib/ecto/adapters/clickhouse/connection.ex
@@ -832,7 +832,7 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
   defp expr({:json_extract_path, _, [expr, path]}, sources, params, query) do
     path =
       Enum.map(path, fn
-        bin when is_binary(bin) -> [?., quote_name(bin, ?`)]
+        bin when is_binary(bin) -> [?., quote_name(bin)]
         int when is_integer(int) -> [?[, Integer.to_string(int), ?]]
       end)
 
@@ -1029,13 +1029,12 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
   def build_params(_ix, _len = 0, _params), do: []
 
   @doc false
-  def quote_name(name, quoter \\ ?")
-  def quote_name(nil, quoter) when quoter in [?\", ?`], do: []
+  def quote_name(nil), do: []
 
-  def quote_name(name, quoter) when quoter in [?\", ?`] do
+  def quote_name(name) do
     name
     |> unquoted_name()
-    |> quote_with(quoter)
+    |> quote_with(?")
   end
 
   @doc false
@@ -1070,7 +1069,7 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
     [quoter, escape_quoted(value, quoter), quoter]
   end
 
-  defp escape_quoted(value, quoter) when quoter in [?', ?\", ?`] do
+  defp escape_quoted(value, quoter) when quoter in [?', ?\"] do
     # Neutralize existing escape sequences before escaping the active delimiter.
     # ClickHouse accepts both '' and \'; emit SQL-style doubling canonically.
     escaped_quoter = if quoter == ?', do: "''", else: <<?\\, quoter>>

--- a/lib/ecto/adapters/clickhouse/migration.ex
+++ b/lib/ecto/adapters/clickhouse/migration.ex
@@ -268,7 +268,7 @@ defmodule Ecto.Adapters.ClickHouse.Migration do
 
   defp comment(%Table{} = table) do
     if comment = table.comment do
-      [" COMMENT ", @conn.quote_name(comment, ?')]
+      [" COMMENT ", @conn.quote_string(comment)]
     else
       []
     end
@@ -381,7 +381,7 @@ defmodule Ecto.Adapters.ClickHouse.Migration do
   defp null_expr(_), do: []
 
   defp comment_expr(nil), do: []
-  defp comment_expr(comment), do: [" COMMENT '", @conn.escape_string(comment), ?']
+  defp comment_expr(comment), do: [" COMMENT ", @conn.quote_string(comment)]
 
   @dialyzer {:no_improper_lists, default_expr: 2}
   defp default_expr({:ok, nil}, _type) do
@@ -389,7 +389,7 @@ defmodule Ecto.Adapters.ClickHouse.Migration do
   end
 
   defp default_expr({:ok, literal}, _type) when is_binary(literal) do
-    [" DEFAULT '", @conn.escape_string(literal), ?']
+    [" DEFAULT ", @conn.quote_string(literal)]
   end
 
   defp default_expr({:ok, literal}, _type) when is_number(literal) do

--- a/test/ecto/adapters/clickhouse/connection_test.exs
+++ b/test/ecto/adapters/clickhouse/connection_test.exs
@@ -820,8 +820,8 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
     assert Connection.quote_name(~s{has\\slash}) |> IO.iodata_to_binary() ==
              ~s{"has\\\\slash"}
 
-    assert Connection.quote_name(~s{has`tick}, ?`) |> IO.iodata_to_binary() ==
-             ~s{`has\\`tick`}
+    assert Connection.quote_name(~s{has`tick}) |> IO.iodata_to_binary() ==
+             ~s{"has`tick"}
 
     assert Connection.quote_name(["nested", nil, :name]) |> IO.iodata_to_binary() ==
              ~s{"nested.name"}
@@ -836,7 +836,7 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
   test "quoted values match the byte-wise oracle for every byte pair" do
     value = for left <- 0..255, right <- 0..255, into: <<>>, do: <<left, right>>
 
-    for quoter <- [?', ?", ?`] do
+    for quoter <- [?', ?"] do
       expected =
         for <<byte <- value>>, into: <<>> do
           cond do
@@ -850,7 +850,7 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
       quoted =
         case quoter do
           ?' -> Connection.quote_string(value)
-          quoter -> Connection.quote_name(value, quoter)
+          ?" -> Connection.quote_name(value)
         end
 
       assert IO.iodata_to_binary(quoted) == <<quoter, expected::binary, quoter>>
@@ -1116,25 +1116,25 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
     assert all(query) == ~s{SELECT s0."meta"[0][1] FROM "schema" AS s0}
 
     query = Schema |> select([s], json_extract_path(s.meta, ["a", "b"]))
-    assert all(query) == ~s{SELECT s0."meta".`a`.`b` FROM "schema" AS s0}
+    assert all(query) == ~s{SELECT s0."meta"."a"."b" FROM "schema" AS s0}
 
     query = Schema |> select([s], json_extract_path(s.meta, ["FROM"]))
-    assert all(query) == ~s{SELECT s0."meta".`FROM` FROM "schema" AS s0}
+    assert all(query) == ~s{SELECT s0."meta"."FROM" FROM "schema" AS s0}
 
     query = Schema |> select([s], json_extract_path(s.meta, ["'a"]))
-    assert all(query) == ~s{SELECT s0."meta".`'a` FROM "schema" AS s0}
+    assert all(query) == ~s{SELECT s0."meta"."'a" FROM "schema" AS s0}
 
     query = Schema |> select([s], json_extract_path(s.meta, ["\"a"]))
-    assert all(query) == ~s{SELECT s0."meta".`"a` FROM "schema" AS s0}
+    assert all(query) == ~s{SELECT s0."meta"."\\"a" FROM "schema" AS s0}
 
     query = Schema |> select([s], json_extract_path(s.meta, ["a b", "a`b"]))
-    assert all(query) == ~s{SELECT s0."meta".`a b`.`a\\`b` FROM "schema" AS s0}
+    assert all(query) == ~s{SELECT s0."meta"."a b"."a`b" FROM "schema" AS s0}
 
     query = Schema |> select([s], json_extract_path(s.meta, ["a\\b"]))
-    assert all(query) == ~S|SELECT s0."meta".`a\\b` FROM "schema" AS s0|
+    assert all(query) == ~S|SELECT s0."meta"."a\\b" FROM "schema" AS s0|
 
     query = Schema |> select([s], s.meta["author"]["name"])
-    assert all(query) == ~s{SELECT s0."meta".`author`.`name` FROM "schema" AS s0}
+    assert all(query) == ~s{SELECT s0."meta"."author"."name" FROM "schema" AS s0}
   end
 
   test "nested expressions" do

--- a/test/ecto/adapters/clickhouse/connection_test.exs
+++ b/test/ecto/adapters/clickhouse/connection_test.exs
@@ -825,17 +825,27 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
     assert query == ~s{INSERT INTO "schema\\"quoted"("field\\"quoted")}
   end
 
-  test "quoted identifier escape matches the byte-wise oracle for every byte pair" do
+  test "quoted values match the byte-wise oracle for every byte pair" do
     value = for left <- 0..255, right <- 0..255, into: <<>>, do: <<left, right>>
 
-    for quoter <- [?", ?`] do
+    for quoter <- [?', ?", ?`] do
       expected =
         for <<byte <- value>>, into: <<>> do
-          if byte in [?\\, quoter], do: <<?\\, byte>>, else: <<byte>>
+          cond do
+            byte == ?\\ -> <<?\\, ?\\>>
+            byte == ?' and quoter == ?' -> <<?', ?'>>
+            byte == quoter -> <<?\\, byte>>
+            true -> <<byte>>
+          end
         end
 
-      assert Connection.quote_name(value, quoter) |> IO.iodata_to_binary() ==
-               <<quoter, expected::binary, quoter>>
+      quoted =
+        case quoter do
+          ?' -> Connection.quote_string(value)
+          quoter -> Connection.quote_name(value, quoter)
+        end
+
+      assert IO.iodata_to_binary(quoted) == <<quoter, expected::binary, quoter>>
     end
   end
 
@@ -1098,7 +1108,10 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
     assert all(query) == ~s{SELECT s0."meta"[0][1] FROM "schema" AS s0}
 
     query = Schema |> select([s], json_extract_path(s.meta, ["a", "b"]))
-    assert all(query) == ~s{SELECT s0."meta".a.b FROM "schema" AS s0}
+    assert all(query) == ~s{SELECT s0."meta".`a`.`b` FROM "schema" AS s0}
+
+    query = Schema |> select([s], json_extract_path(s.meta, ["FROM"]))
+    assert all(query) == ~s{SELECT s0."meta".`FROM` FROM "schema" AS s0}
 
     query = Schema |> select([s], json_extract_path(s.meta, ["'a"]))
     assert all(query) == ~s{SELECT s0."meta".`'a` FROM "schema" AS s0}
@@ -1113,7 +1126,7 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
     assert all(query) == ~S|SELECT s0."meta".`a\\b` FROM "schema" AS s0|
 
     query = Schema |> select([s], s.meta["author"]["name"])
-    assert all(query) == ~s{SELECT s0."meta".author.name FROM "schema" AS s0}
+    assert all(query) == ~s{SELECT s0."meta".`author`.`name` FROM "schema" AS s0}
   end
 
   test "nested expressions" do

--- a/test/ecto/adapters/clickhouse/connection_test.exs
+++ b/test/ecto/adapters/clickhouse/connection_test.exs
@@ -811,6 +811,8 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
 
     assert Connection.quote_string(~S|has\'quote|) |> IO.iodata_to_binary() ==
              ~S|'has\\''quote'|
+
+    assert_raise FunctionClauseError, fn -> apply(Connection, :quote_string, [1]) end
   end
 
   test "quoted identifier escape" do

--- a/test/ecto/adapters/clickhouse/connection_test.exs
+++ b/test/ecto/adapters/clickhouse/connection_test.exs
@@ -808,6 +808,9 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
     value = "let's \\ escape"
     query = "schema" |> select([], fragment("?", constant(^value)))
     assert all(query) == ~s[SELECT 'let''s \\\\ escape' FROM "schema" AS s0]
+
+    assert Connection.quote_string(~S|has\'quote|) |> IO.iodata_to_binary() ==
+             ~S|'has\\''quote'|
   end
 
   test "quoted identifier escape" do
@@ -819,6 +822,11 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
 
     assert Connection.quote_name(~s{has`tick}, ?`) |> IO.iodata_to_binary() ==
              ~s{`has\\`tick`}
+
+    assert Connection.quote_name(["nested", nil, :name]) |> IO.iodata_to_binary() ==
+             ~s{"nested.name"}
+
+    assert_raise FunctionClauseError, fn -> apply(Connection, :quote_name, [1]) end
 
     query = insert(nil, ~s{schema"quoted}, [~s{field"quoted}], [], :raise, [])
 

--- a/test/ecto/adapters/clickhouse/connection_test.exs
+++ b/test/ecto/adapters/clickhouse/connection_test.exs
@@ -825,17 +825,27 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
     assert query == ~s{INSERT INTO "schema\\"quoted"("field\\"quoted")}
   end
 
-  test "quoted identifier escape matches the byte-wise oracle for every byte pair" do
+  test "quoted values match the byte-wise oracle for every byte pair" do
     value = for left <- 0..255, right <- 0..255, into: <<>>, do: <<left, right>>
 
-    for quoter <- [?", ?`] do
+    for quoter <- [?', ?", ?`] do
       expected =
         for <<byte <- value>>, into: <<>> do
-          if byte in [?\\, quoter], do: <<?\\, byte>>, else: <<byte>>
+          cond do
+            byte == ?\\ -> <<?\\, ?\\>>
+            byte == ?' and quoter == ?' -> <<?', ?'>>
+            byte == quoter -> <<?\\, byte>>
+            true -> <<byte>>
+          end
         end
 
-      assert Connection.quote_name(value, quoter) |> IO.iodata_to_binary() ==
-               <<quoter, expected::binary, quoter>>
+      quoted =
+        case quoter do
+          ?' -> Connection.quote_string(value)
+          quoter -> Connection.quote_name(value, quoter)
+        end
+
+      assert IO.iodata_to_binary(quoted) == <<quoter, expected::binary, quoter>>
     end
   end
 
@@ -1063,7 +1073,10 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
     assert all(query) == ~s{SELECT s0."meta"[0][1] FROM "schema" AS s0}
 
     query = Schema |> select([s], json_extract_path(s.meta, ["a", "b"]))
-    assert all(query) == ~s{SELECT s0."meta".a.b FROM "schema" AS s0}
+    assert all(query) == ~s{SELECT s0."meta".`a`.`b` FROM "schema" AS s0}
+
+    query = Schema |> select([s], json_extract_path(s.meta, ["FROM"]))
+    assert all(query) == ~s{SELECT s0."meta".`FROM` FROM "schema" AS s0}
 
     query = Schema |> select([s], json_extract_path(s.meta, ["'a"]))
     assert all(query) == ~s{SELECT s0."meta".`'a` FROM "schema" AS s0}
@@ -1078,7 +1091,7 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
     assert all(query) == ~S|SELECT s0."meta".`a\\b` FROM "schema" AS s0|
 
     query = Schema |> select([s], s.meta["author"]["name"])
-    assert all(query) == ~s{SELECT s0."meta".author.name FROM "schema" AS s0}
+    assert all(query) == ~s{SELECT s0."meta".`author`.`name` FROM "schema" AS s0}
   end
 
   test "nested expressions" do

--- a/test/ecto/adapters/clickhouse/migration_test.exs
+++ b/test/ecto/adapters/clickhouse/migration_test.exs
@@ -2,6 +2,7 @@ defmodule Ecto.Adapters.ClickHouse.MigrationTest do
   use ExUnit.Case
 
   alias Ecto.Adapters.ClickHouse
+  alias Ecto.Adapters.ClickHouse.Connection
 
   defmodule MigrationRepo do
     use Ecto.Repo, adapter: Ecto.Adapters.ClickHouse, otp_app: :migration_test
@@ -72,6 +73,29 @@ defmodule Ecto.Adapters.ClickHouse.MigrationTest do
         modify :price, :UInt64, default: 1
       end
     end
+  end
+
+  defmodule QuotedDDL do
+    use Ecto.Migration
+
+    @table_name "ecto_ch quoted ' \" ` \\ ; -- /* */ $tag$ table \\"
+    @column_name String.to_atom("value ' \" ` \\ ; -- /* */ $tag$ column \\")
+    @escaped_text "single ' double \" backtick ` backslash \\ pair \\' ; -- /* */ $tag$ body $tag$\ntrailing \\"
+
+    def change do
+      create table(@table_name,
+               primary_key: false,
+               engine: "Memory",
+               comment: @escaped_text
+             ) do
+        add :id, :UInt8
+        add @column_name, :string, default: @escaped_text, comment: @escaped_text
+      end
+    end
+
+    def table_name, do: @table_name
+    def column_name, do: Atom.to_string(@column_name)
+    def escaped_text, do: @escaped_text
   end
 
   test "events (table+index)" do
@@ -203,5 +227,65 @@ defmodule Ecto.Adapters.ClickHouse.MigrationTest do
              Ch.query!(conn, "INSERT INTO products (name) VALUES ('book')")
 
     assert [[1]] == Ch.query!(conn, "SELECT price FROM products").rows
+  end
+
+  test "quoted names, defaults, and comments round-trip through ClickHouse" do
+    database = "ecto_ch_migration_test_quoted_ddl"
+    opts = [database: database]
+
+    assert :ok = ClickHouse.storage_up(opts)
+    on_exit(fn -> ClickHouse.storage_down(opts) end)
+
+    Application.put_env(:migration_test, MigrationRepo,
+      database: database,
+      show_sensitive_data_on_connection_error: true
+    )
+
+    on_exit(fn -> Application.delete_env(:migration_test, MigrationRepo) end)
+
+    start_supervised!(MigrationRepo)
+
+    assert [1] ==
+             Ecto.Migrator.run(MigrationRepo, [{1, QuotedDDL}], :up,
+               all: true,
+               log: false
+             )
+
+    conn = start_supervised!({Ch, opts})
+    table = QuotedDDL.table_name()
+    column = QuotedDDL.column_name()
+    escaped_text = QuotedDDL.escaped_text()
+    params = %{"database" => database, "table" => table, "column" => column}
+
+    assert [[^escaped_text]] =
+             Ch.query!(
+               conn,
+               "SELECT comment FROM system.tables WHERE database = {database:String} AND name = {table:String}",
+               params
+             ).rows
+
+    assert [[^escaped_text]] =
+             Ch.query!(
+               conn,
+               "SELECT comment FROM system.columns WHERE database = {database:String} AND table = {table:String} AND name = {column:String}",
+               params
+             ).rows
+
+    quoted_table = Connection.quote_name(table)
+    quoted_column = Connection.quote_name(column)
+
+    insert_sql =
+      IO.iodata_to_binary([
+        "INSERT INTO ",
+        quoted_table,
+        " (\"id\") VALUES (1)"
+      ])
+
+    Ch.query!(conn, insert_sql)
+
+    select_sql = IO.iodata_to_binary(["SELECT ", quoted_column, " FROM ", quoted_table])
+    result = Ch.query!(conn, select_sql)
+
+    assert result.rows == [[escaped_text]]
   end
 end

--- a/test/ecto/integration/json_test.exs
+++ b/test/ecto/integration/json_test.exs
@@ -88,6 +88,7 @@ defmodule Ecto.Integration.JsonTest do
     TestRepo.insert_all(SemiStructured, [
       %{
         json: %{
+          "FROM" => "keyword",
           "from" => "insert_all",
           "nested" => %{"name" => "Test", "arr" => ["abc", "b=deb"]},
           "edge cases" => %{
@@ -112,6 +113,7 @@ defmodule Ecto.Integration.JsonTest do
     assert TestRepo.all(
              from s in SemiStructured,
                select: %{
+                 keyword: json_extract_path(s.json, ["FROM"]),
                  from: json_extract_path(s.json, ["from"]),
                  name: json_extract_path(s.json, ["nested", "name"]),
                  edge_space: json_extract_path(s.json, ["edge cases", "space key"]),
@@ -130,6 +132,7 @@ defmodule Ecto.Integration.JsonTest do
                }
            ) == [
              %{
+               keyword: "keyword",
                from: "insert_all",
                name: "Test",
                edge_space: "space",

--- a/test/ecto/integration/json_test.exs
+++ b/test/ecto/integration/json_test.exs
@@ -103,7 +103,12 @@ defmodule Ecto.Integration.JsonTest do
             "comma,key" => "comma",
             "colon:key" => "colon",
             "slash/key" => "slash",
-            "bracket[key]" => "bracket"
+            "bracket[key]" => "bracket",
+            "trailing\\" => "trailing_backslash",
+            "backslash\\`backtick" => "backslash_backtick",
+            "all'\"`\\quotes" => "all_quotes",
+            "line\nbreak" => "newline",
+            "; -- /* comment */ $tag$ body $tag$" => "syntax"
           }
         },
         time: ~N[2023-10-01 13:00:00]
@@ -128,6 +133,16 @@ defmodule Ecto.Integration.JsonTest do
                  edge_colon: json_extract_path(s.json, ["edge cases", "colon:key"]),
                  edge_slash: json_extract_path(s.json, ["edge cases", "slash/key"]),
                  edge_bracket: json_extract_path(s.json, ["edge cases", "bracket[key]"]),
+                 edge_trailing_backslash: json_extract_path(s.json, ["edge cases", "trailing\\"]),
+                 edge_backslash_backtick:
+                   json_extract_path(s.json, ["edge cases", "backslash\\`backtick"]),
+                 edge_all_quotes: json_extract_path(s.json, ["edge cases", "all'\"`\\quotes"]),
+                 edge_newline: json_extract_path(s.json, ["edge cases", "line\nbreak"]),
+                 edge_syntax:
+                   json_extract_path(s.json, [
+                     "edge cases",
+                     "; -- /* comment */ $tag$ body $tag$"
+                   ]),
                  bracket_name: s.json["nested"]["name"]
                }
            ) == [
@@ -147,6 +162,11 @@ defmodule Ecto.Integration.JsonTest do
                edge_colon: "colon",
                edge_slash: "slash",
                edge_bracket: "bracket",
+               edge_trailing_backslash: "trailing_backslash",
+               edge_backslash_backtick: "backslash_backtick",
+               edge_all_quotes: "all_quotes",
+               edge_newline: "newline",
+               edge_syntax: "syntax",
                bracket_name: "Test"
              }
            ]

--- a/test/ecto/integration/sql_test.exs
+++ b/test/ecto/integration/sql_test.exs
@@ -78,15 +78,11 @@ defmodule Ecto.Integration.SQLTest do
 
     assert result.rows == [[string]]
 
-    for {quoter, name} <- [
-          {?\", ~S|alias" FROM numbers(10) -- \ $tag$body$tag$ /* comment */|},
-          {?`, ~S|alias` FROM numbers(10) -- \ $tag$body$tag$ /* comment */|}
-        ] do
-      result = TestRepo.query!(["SELECT 1 AS ", Connection.quote_name(name, quoter)])
+    name = ~S|alias"` FROM numbers(10) -- \ $tag$body$tag$ /* comment */|
+    result = TestRepo.query!(["SELECT 1 AS ", Connection.quote_name(name)])
 
-      assert result.columns == [name]
-      assert result.rows == [[1]]
-    end
+    assert result.columns == [name]
+    assert result.rows == [[1]]
   end
 
   test "bound parameters and inline literals round-trip escaping edge cases" do
@@ -141,7 +137,7 @@ defmodule Ecto.Integration.SQLTest do
         "SELECT ",
         quoted_column,
         " AS ",
-        Connection.quote_name(alias_name, ?`),
+        Connection.quote_name(alias_name),
         " FROM ",
         quoted_table
       ])

--- a/test/ecto/integration/sql_test.exs
+++ b/test/ecto/integration/sql_test.exs
@@ -7,6 +7,21 @@ defmodule Ecto.Integration.SQLTest do
 
   import Ecto.Query
 
+  defmodule QuotedNames do
+    use Ecto.Schema
+
+    @primary_key false
+    @table_name "ecto_ch quoted ' \" ` \\ ; -- /* */ $tag$ table \\"
+    @column_name String.to_atom("value ' \" ` \\ ; -- /* */ $tag$ column \\")
+
+    schema @table_name do
+      field :value, :string, source: @column_name
+    end
+
+    def table_name, do: @table_name
+    def column_name, do: Atom.to_string(@column_name)
+  end
+
   test "fragmented types" do
     datetime = ~N[2014-01-16 20:26:51]
 
@@ -72,6 +87,67 @@ defmodule Ecto.Integration.SQLTest do
       assert result.columns == [name]
       assert result.rows == [[1]]
     end
+  end
+
+  test "bound parameters and inline literals round-trip escaping edge cases" do
+    values = [
+      "",
+      "'",
+      "\\",
+      ~S|\'|,
+      "'\\",
+      "\\\\'",
+      "single ' double \" backtick ` backslash \\ middle",
+      "ends with \\",
+      "; SELECT 2; -- /* comment */ $tag$ heredoc $tag$",
+      "line one\nline two\r\n\t",
+      "\u00E9\u0416\u4E2D\u6587",
+      :binary.list_to_bin(Enum.to_list(0..127))
+    ]
+
+    for value <- values do
+      query =
+        from _ in "one",
+          select: {type(^value, :string), fragment("?", constant(^value))}
+
+      assert TestRepo.one(query, database: "system") == {value, value}
+    end
+  end
+
+  test "quoted table, column, and alias names round-trip through ClickHouse" do
+    table = QuotedNames.table_name()
+    column = QuotedNames.column_name()
+    quoted_table = Connection.quote_name(table)
+    quoted_column = Connection.quote_name(column)
+
+    TestRepo.query!([
+      "CREATE TABLE ",
+      quoted_table,
+      " (",
+      quoted_column,
+      " String) ENGINE Memory"
+    ])
+
+    on_exit(fn -> TestRepo.query!(["DROP TABLE IF EXISTS ", quoted_table]) end)
+
+    value = "value with ' \" ` \\ and \\' adjacent"
+    assert %QuotedNames{value: ^value} = TestRepo.insert!(%QuotedNames{value: value})
+    assert [^value] = TestRepo.all(from row in QuotedNames, select: row.value)
+
+    alias_name = "alias ' \" ` \\ ; -- /* */ $tag$ \\"
+
+    result =
+      TestRepo.query!([
+        "SELECT ",
+        quoted_column,
+        " AS ",
+        Connection.quote_name(alias_name, ?`),
+        " FROM ",
+        quoted_table
+      ])
+
+    assert result.columns == [alias_name]
+    assert result.rows == [[value]]
   end
 
   test "disconnect_all/2" do

--- a/test/ecto/integration/sql_test.exs
+++ b/test/ecto/integration/sql_test.exs
@@ -59,7 +59,7 @@ defmodule Ecto.Integration.SQLTest do
 
   test "quoted strings and identifiers cannot break out into ClickHouse syntax" do
     string = ~S|value' FROM numbers(10) -- \ $tag$body$tag$ /* comment */|
-    result = TestRepo.query!(["SELECT ", Connection.quote_name(string, ?')])
+    result = TestRepo.query!(["SELECT ", Connection.quote_string(string)])
 
     assert result.rows == [[string]]
 


### PR DESCRIPTION
Separates double-quoted identifier quoting (`quote_name/1`) from single-quoted string-literal quoting (`quote_string/1`) while routing both through one escape-and-wrap implementation.

It updates query and migration emitters to consume complete quoted literals, removing manual delimiter assembly and preserving ClickHouse quote and backslash semantics.

JSON path segments now use the same double-quoted identifier helper, removing a regex that accepted keyword-shaped keys such as `FROM` and avoiding both a duplicate identifier classifier and an unnecessary backtick output mode.

Validation includes ClickHouse round trips for bound and inline strings, JSON keys, quoted table/column/alias names, and migration comments/defaults, plus `MIX_ENV=test mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix test` (508 passed, 82 skipped), and `mix dialyzer --format github`.
