### PR TITLE
Reject unsupported Ecto bitstring type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Raise an explicit error for the unsupported Ecto `:bitstring` type
+- Raise an explicit error for the unsupported Ecto `:bitstring` type https://github.com/plausible/ecto_ch/pull/305
 - Preserve semicolons inside literals, quoted identifiers, heredocs, and comments when loading structure dumps https://github.com/plausible/ecto_ch/pull/293
 - Raise when combination queries have a parent `LIMIT` or `OFFSET` and direct callers to wrap the combination in `subquery/1` https://github.com/plausible/ecto_ch/pull/301
 - Escape double quotes, backticks, and backslashes in quoted ClickHouse identifiers https://github.com/plausible/ecto_ch/pull/283

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Raise an explicit error for the unsupported Ecto `:bitstring` type
 - Preserve semicolons inside literals, quoted identifiers, heredocs, and comments when loading structure dumps https://github.com/plausible/ecto_ch/pull/293
 - Raise when combination queries have a parent `LIMIT` or `OFFSET` and direct callers to wrap the combination in `subquery/1` https://github.com/plausible/ecto_ch/pull/301
 - Escape double quotes, backticks, and backslashes in quoted ClickHouse identifiers https://github.com/plausible/ecto_ch/pull/283

--- a/lib/ecto/adapters/clickhouse/migration.ex
+++ b/lib/ecto/adapters/clickhouse/migration.ex
@@ -439,6 +439,10 @@ defmodule Ecto.Adapters.ClickHouse.Migration do
     raise ArgumentError, "type :numeric is not supported"
   end
 
+  defp column_type(:bitstring) do
+    raise ArgumentError, "type :bitstring is not supported"
+  end
+
   defp column_type(:map) do
     raise ArgumentError,
           ~s[type :map is ambiguous, use a literal (e.g. :JSON or :"Map(String, UInt8)") instead]

--- a/lib/ecto/adapters/clickhouse/schema.ex
+++ b/lib/ecto/adapters/clickhouse/schema.ex
@@ -286,6 +286,10 @@ defmodule Ecto.Adapters.ClickHouse.Schema do
 
   defp remap_type(:time_usec, _original, _schema, _field), do: {:time64, _precision = 6}
 
+  defp remap_type(:bitstring, _original, _schema, _field) do
+    raise ArgumentError, "type :bitstring is not supported"
+  end
+
   # TODO remove
   defp remap_type(t, _original, _schema, _field)
        when t in [:binary, :binary_id],

--- a/test/ecto/adapters/clickhouse/api_test.exs
+++ b/test/ecto/adapters/clickhouse/api_test.exs
@@ -16,6 +16,15 @@ defmodule Ecto.Adapters.ClickHouse.APITest do
     end
   end
 
+  defmodule BitstringSchema do
+    use Ecto.Schema
+
+    @primary_key false
+    schema "bitstrings" do
+      field :bits, :bitstring
+    end
+  end
+
   defp plan(query, operation) do
     {query, _cast_params, dump_params} =
       Ecto.Adapter.Queryable.plan_query(operation, ClickHouse, query)
@@ -50,6 +59,12 @@ defmodule Ecto.Adapters.ClickHouse.APITest do
       assert all(query) == """
              SELECT f0."a",arrayReduce('argMaxState', [f0."b"], [f0."a"]) FROM input("a Int16, b String") AS f0\
              """
+    end
+
+    test "schema with unsupported bitstring type" do
+      assert_raise ArgumentError, "type :bitstring is not supported", fn ->
+        API.input(BitstringSchema)
+      end
     end
   end
 end

--- a/test/ecto/adapters/clickhouse/connection_test.exs
+++ b/test/ecto/adapters/clickhouse/connection_test.exs
@@ -2807,6 +2807,14 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
     end
   end
 
+  test "create table with a bitstring column" do
+    create = {:create, table(:posts), [{:add, :bits, :bitstring, []}]}
+
+    assert_raise ArgumentError, "type :bitstring is not supported", fn ->
+      execute_ddl(create)
+    end
+  end
+
   test "drop table" do
     drop = {:drop, table(:posts), :restrict}
     assert execute_ddl(drop) == [~s|DROP TABLE "posts"|]


### PR DESCRIPTION
Ecto `:bitstring` has no faithful generic ClickHouse mapping, but migrations previously emitted an invalid `bitstring` type and schema remapping fell through to an incidental `unknown type` error.

This change rejects it explicitly in both paths, adds regression coverage, and documents the behavior in the Unreleased changelog.

Validated with `mix compile --warnings-as-errors`, `mix format --check-formatted`, and `mix test` (502 passed, 82 skipped).
