### PR TITLE
Support tagged datetime and binary ID casts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fix explicit `type/2` casts for `:naive_datetime`, `:utc_datetime`, their microsecond variants, and `:binary_id`
+- Fix explicit `type/2` casts for `:naive_datetime`, `:utc_datetime`, their microsecond variants, and `:binary_id` https://github.com/plausible/ecto_ch/pull/306
 - Preserve semicolons inside literals, quoted identifiers, heredocs, and comments when loading structure dumps https://github.com/plausible/ecto_ch/pull/293
 - Raise when combination queries have a parent `LIMIT` or `OFFSET` and direct callers to wrap the combination in `subquery/1` https://github.com/plausible/ecto_ch/pull/301
 - Escape double quotes, backticks, and backslashes in quoted ClickHouse identifiers https://github.com/plausible/ecto_ch/pull/283

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix explicit `type/2` casts for `:naive_datetime`, `:utc_datetime`, their microsecond variants, and `:binary_id`
 - Preserve semicolons inside literals, quoted identifiers, heredocs, and comments when loading structure dumps https://github.com/plausible/ecto_ch/pull/293
 - Raise when combination queries have a parent `LIMIT` or `OFFSET` and direct callers to wrap the combination in `subquery/1` https://github.com/plausible/ecto_ch/pull/301
 - Escape double quotes, backticks, and backslashes in quoted ClickHouse identifiers https://github.com/plausible/ecto_ch/pull/283

--- a/lib/ecto/adapters/clickhouse/connection.ex
+++ b/lib/ecto/adapters/clickhouse/connection.ex
@@ -1128,7 +1128,7 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
   # so we need :integer to be the same as :bigint which is used for schema_versions table definition
   # this is why :integer is Int64 and not Int32
   defp ecto_to_db(:integer, _query), do: "Int64"
-  defp ecto_to_db(:binary, _query), do: "String"
+  defp ecto_to_db(type, _query) when type in [:binary, :binary_id], do: "String"
   defp ecto_to_db({:parameterized, {Ch, type}}, _query), do: Ch.Types.encode(type)
   defp ecto_to_db({:array, type}, query), do: ["Array(", ecto_to_db(type, query), ?)]
 
@@ -1137,6 +1137,15 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
   end
 
   defp ecto_to_db(:time_usec, _query), do: Ch.Types.encode({:time64, 6})
+
+  defp ecto_to_db(type, _query) when type in [:naive_datetime, :utc_datetime] do
+    Ch.Types.encode(:datetime)
+  end
+
+  defp ecto_to_db(type, _query)
+       when type in [:naive_datetime_usec, :utc_datetime_usec] do
+    Ch.Types.encode({:datetime64, 6})
+  end
 
   defp ecto_to_db(type, query) do
     raise Ecto.QueryError,

--- a/test/ecto/adapters/clickhouse/connection_test.exs
+++ b/test/ecto/adapters/clickhouse/connection_test.exs
@@ -1044,6 +1044,41 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
              ~s[SELECT CAST(e0."count" + CAST(1 AS Time64(6)) AS Time64(6)) FROM "events" AS e0]
   end
 
+  test "tagged datetime types" do
+    naive_datetime = ~N[2024-04-12 09:55:54]
+    naive_datetime_usec = ~N[2024-04-12 09:55:54.123456]
+    utc_datetime = ~U[2024-04-12 09:55:54Z]
+    utc_datetime_usec = ~U[2024-04-12 09:55:54.123456Z]
+
+    query = from e in "events", select: type(^naive_datetime, :naive_datetime)
+
+    assert all(query) ==
+             ~s[SELECT CAST({$0:DateTime} AS DateTime) FROM "events" AS e0]
+
+    query = from e in "events", select: type(^naive_datetime_usec, :naive_datetime_usec)
+
+    assert all(query) ==
+             ~s[SELECT CAST({$0:DateTime64(6)} AS DateTime64(6)) FROM "events" AS e0]
+
+    query = from e in "events", select: type(^utc_datetime, :utc_datetime)
+
+    assert all(query) ==
+             ~s[SELECT CAST({$0:DateTime} AS DateTime) FROM "events" AS e0]
+
+    query = from e in "events", select: type(^utc_datetime_usec, :utc_datetime_usec)
+
+    assert all(query) ==
+             ~s[SELECT CAST({$0:DateTime64(6)} AS DateTime64(6)) FROM "events" AS e0]
+  end
+
+  test "tagged binary_id type" do
+    binary_id = Ecto.UUID.generate()
+    query = from e in "events", select: type(^binary_id, :binary_id)
+
+    assert all(query) ==
+             ~s[SELECT CAST({$0:String} AS String) FROM "events" AS e0]
+  end
+
   test "tagged unknown type" do
     query = from e in "events", select: type(e.count + 1, :decimal)
 


### PR DESCRIPTION
Explicit Ecto `type/2` casts for datetime and binary ID types raised `Ecto.QueryError` because the tagged-cast mapping omitted types already supported by schema storage.

This maps naive and UTC datetime variants to `DateTime`/`DateTime64(6)` and `:binary_id` to `String`. Regression coverage verifies bound parameters generate the expected ClickHouse casts, and the fix is documented in the changelog.

Validation: the focused regressions, complete connection suite (192 passed, 4 skipped), broader adapter/unit suite (261 passed, 4 skipped), warnings-as-errors compilation, formatting, and diff checks pass.
