### PR TITLE
Use Date32 for out-of-range date params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Use `Date32` for bound date parameters before 1970 or after 2148
+- Use `Date32` for bound date parameters before 1970 or after 2148 https://github.com/plausible/ecto_ch/pull/307
 - Preserve semicolons inside literals, quoted identifiers, heredocs, and comments when loading structure dumps https://github.com/plausible/ecto_ch/pull/293
 - Raise when combination queries have a parent `LIMIT` or `OFFSET` and direct callers to wrap the combination in `subquery/1` https://github.com/plausible/ecto_ch/pull/301
 - Escape double quotes, backticks, and backslashes in quoted ClickHouse identifiers https://github.com/plausible/ecto_ch/pull/283

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Use `Date32` for bound date parameters before 1970 or after 2148
 - Preserve semicolons inside literals, quoted identifiers, heredocs, and comments when loading structure dumps https://github.com/plausible/ecto_ch/pull/293
 - Raise when combination queries have a parent `LIMIT` or `OFFSET` and direct callers to wrap the combination in `subquery/1` https://github.com/plausible/ecto_ch/pull/301
 - Escape double quotes, backticks, and backslashes in quoted ClickHouse identifiers https://github.com/plausible/ecto_ch/pull/283

--- a/lib/ecto/adapters/clickhouse/connection.ex
+++ b/lib/ecto/adapters/clickhouse/connection.ex
@@ -1258,7 +1258,7 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
     end
   end
 
-  # TODO Date32
+  defp param_type(%Date{year: year}) when year < 1970 or year > 2148, do: "Date32"
   defp param_type(%Date{}), do: "Date"
 
   defp param_type(%Time{microsecond: {_value, precision}}) when precision > 0 do

--- a/test/ecto/adapters/clickhouse/connection_test.exs
+++ b/test/ecto/adapters/clickhouse/connection_test.exs
@@ -3468,6 +3468,13 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
            ]
   end
 
+  test "Date and Date32 params" do
+    params = [~D[1969-12-31], ~D[1970-01-01], ~D[2148-12-31], ~D[2149-01-01]]
+
+    assert Connection.build_params(_ix = 0, _len = 4, params) |> IO.iodata_to_binary() ==
+             "{$0:Date32},{$1:Date},{$2:Date},{$3:Date32}"
+  end
+
   # https://github.com/plausible/ecto_ch/issues/178
   test "DateTime64 params" do
     assert all(


### PR DESCRIPTION
## Summary

Bound `%Date{}` parameters before 1970 or after 2148 as `Date32`, matching inline parameter behavior. Previously, `param_type/1` always emitted `Date`, so ClickHouse could not represent out-of-range bound dates correctly. Added cutoff boundary coverage and documented the change.

## Validation

- `mix test test/ecto/adapters/clickhouse/connection_test.exs` — 191 passed, 4 skipped
- `mix test test/ecto/integration/logging_test.exs` — 17 passed, 8 skipped
- `mix compile --warnings-as-errors`
- `mix format --check-formatted`
