### PR TITLE
Avoid insert type warning in tests

### DIFF
--- a/test/ecto/adapters/clickhouse/connection_test.exs
+++ b/test/ecto/adapters/clickhouse/connection_test.exs
@@ -2409,13 +2409,27 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
     assert_raise ArgumentError,
                  "ClickHouse does not support RETURNING on INSERT statements",
                  fn ->
-                   insert(nil, "schema", [:x, :y], [[:x, :y]], {:raise, [], []}, [:id])
+                   apply(&insert/6, [
+                     nil,
+                     "schema",
+                     [:x, :y],
+                     [[:x, :y]],
+                     {:raise, [], []},
+                     [:id]
+                   ])
                  end
 
     assert_raise ArgumentError,
                  "ClickHouse does not support RETURNING on INSERT statements",
                  fn ->
-                   insert(nil, "schema", [:x, :y], [[:x, :y], [nil, :z]], {:raise, [], []}, [:id])
+                   apply(&insert/6, [
+                     nil,
+                     "schema",
+                     [:x, :y],
+                     [[:x, :y], [nil, :z]],
+                     {:raise, [], []},
+                     [:id]
+                   ])
                  end
   end
 

--- a/test/ecto/adapters/clickhouse/connection_test.exs
+++ b/test/ecto/adapters/clickhouse/connection_test.exs
@@ -2406,6 +2406,8 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
     query = insert("prefix", "schema", [], [[]], {:raise, [], []}, [])
     assert query == ~s{INSERT INTO "prefix"."schema"}
 
+    # Invoke dynamically because these tests intentionally exercise a path that the type checker
+    # knows always raises for a non-empty returning list.
     assert_raise ArgumentError,
                  "ClickHouse does not support RETURNING on INSERT statements",
                  fn ->


### PR DESCRIPTION
## Summary

- Invoke the two intentional non-empty `RETURNING` test cases dynamically with `apply/2`.
- Elixir 1.20 infers that the insert helper only returns normally when its sixth argument is `[]`, so direct calls to the expected exception path emitted incompatible-types warnings.
- This keeps production behavior unchanged while allowing warnings-as-errors test runs to pass.

## Validation

- `mix test --warnings-as-errors` (508 passed, 82 skipped)
